### PR TITLE
feat: Issue起点の開発ワークフロー構築

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -10,7 +10,12 @@
       "Bash(git branch*)",
       "Bash(git checkout*)",
       "Bash(git add*)",
-      "Bash(git commit*)"
+      "Bash(git commit*)",
+      "Bash(gh issue view*)",
+      "Bash(gh issue comment*)",
+      "Bash(gh issue edit*)",
+      "Bash(gh pr create*)",
+      "Bash(gh pr view*)"
     ],
     "deny": [
       "Bash(git push --force*)",

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -11,6 +11,7 @@
       "Bash(git checkout*)",
       "Bash(git add*)",
       "Bash(git commit*)",
+      "Bash(gh issue create*)",
       "Bash(gh issue view*)",
       "Bash(gh issue comment*)",
       "Bash(gh issue edit*)",

--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ PR_DESCRIPTION.md
 
 # Claude Code (local settings)
 .claude/settings.local.json
+.claude/issue-context.md
 
 # Serena MCP (local tool config)
 .serena/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,6 +80,60 @@ npm run build-storybook # Storybook ビルド
 - `develop`: 開発ブランチ（PR のベースブランチ）
 - 作業ブランチ: `feature/<name>`, `fix/<name>`, `chore/<name>` などの形式
 
+## Issue 起点の開発ワークフロー
+
+### スタート手順
+
+```bash
+./scripts/issue-start.sh <issue番号>
+```
+
+このスクリプトが以下を自動で行う:
+- Issue の内容を取得
+- ラベルに応じたブランチ名を生成して checkout (`feature/issue-{番号}-{slug}`)
+- `.claude/issue-context.md` にコンテキストファイルを生成
+
+その後 Claude Code を起動すると、コンテキストファイルを自動で読み込む。
+
+### Claude Code との作業手順
+
+1. **タスク分解**: Issue の内容をもとに具体的な実装タスクを対話で決定する
+2. **Issue にタスクを記録**: 合意したタスクをチェックリストとして Issue にコメントする
+   ```bash
+   gh issue comment <番号> --body "## タスク\n- [ ] ..."
+   ```
+3. **実装**: タスクを順番に実装してコミットする
+4. **PR 作成**: `Closes #<番号>` を本文に含めた PR を作成する
+
+### ブランチ命名規則
+
+| ラベル | プレフィックス |
+|---|---|
+| bug / fix | `fix/` |
+| chore / setup / ci | `chore/` |
+| docs | `docs/` |
+| refactor | `refactor/` |
+| その他 | `feature/` |
+
+形式: `{prefix}/issue-{番号}-{タイトルのslug}`
+
+### PR テンプレート
+
+```markdown
+## 概要
+<!-- 変更内容を簡潔に -->
+
+## 対応 Issue
+Closes #{番号}
+
+## 変更内容
+- 
+
+## 確認事項
+- [ ] lint エラーなし (`npm run lint`)
+- [ ] ビルド成功 (`npm run build`)
+```
+
 ## 注意事項
 
 - テストランナーは現時点で未設定。テストを追加する場合は Jest + React Testing Library の導入を検討すること

--- a/scripts/issue-start.sh
+++ b/scripts/issue-start.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# Usage: ./scripts/issue-start.sh <issue-number>
+# GitHub Issue を取得し、ブランチを切って Claude Code のコンテキストを準備する
+
+set -euo pipefail
+
+ISSUE_NUMBER="${1:?Usage: $0 <issue-number>}"
+
+# --- Issue 取得 (jq 不要: gh --template を使用) ---
+echo "=== Issue #${ISSUE_NUMBER} を取得中... ==="
+
+TITLE=$(gh issue view "$ISSUE_NUMBER" --json title  --template '{{.title}}')
+BODY=$(gh issue view  "$ISSUE_NUMBER" --json body   --template '{{.body}}')
+STATE=$(gh issue view "$ISSUE_NUMBER" --json state  --template '{{.state}}')
+LABELS=$(gh issue view "$ISSUE_NUMBER" --json labels --template '{{range .labels}}{{.name}} {{end}}')
+
+BODY="${BODY:-"(本文なし)"}"
+LABELS="${LABELS:-"(なし)"}"
+
+if [ "$STATE" = "CLOSED" ]; then
+  echo "警告: Issue #${ISSUE_NUMBER} はすでにクローズされています。続けますか？ [y/N]"
+  read -r CONFIRM
+  [[ "$CONFIRM" =~ ^[Yy]$ ]] || exit 0
+fi
+
+# --- ブランチ名生成 ---
+# タイトルを slug 化 (小文字・英数字とハイフンのみ、日本語は除去)
+SLUG=$(echo "$TITLE" \
+  | tr '[:upper:]' '[:lower:]' \
+  | sed 's/[^a-z0-9[:space:]-]//g' \
+  | sed 's/[[:space:]][[:space:]]*/-/g' \
+  | sed 's/--*/-/g' \
+  | sed 's/^-//;s/-$//' \
+  | cut -c1-40)
+
+# slug が空の場合 (タイトルが日本語のみ) は issue番号だけにする
+if [ -z "$SLUG" ]; then
+  SLUG="work"
+fi
+
+# ラベルに応じてプレフィックスを決定
+if echo "$LABELS" | grep -qi "bug\|fix"; then
+  PREFIX="fix"
+elif echo "$LABELS" | grep -qi "chore\|setup\|ci"; then
+  PREFIX="chore"
+elif echo "$LABELS" | grep -qi "docs"; then
+  PREFIX="docs"
+elif echo "$LABELS" | grep -qi "refactor"; then
+  PREFIX="refactor"
+else
+  PREFIX="feature"
+fi
+
+BRANCH_NAME="${PREFIX}/issue-${ISSUE_NUMBER}-${SLUG}"
+
+echo ""
+echo "=== Issue情報 ==="
+echo "  タイトル : $TITLE"
+echo "  ラベル   : $LABELS"
+echo "  ブランチ : $BRANCH_NAME"
+echo ""
+
+# --- ブランチ作成 ---
+# すでに同名ブランチが存在する場合はチェックアウトのみ
+if git show-ref --verify --quiet "refs/heads/${BRANCH_NAME}"; then
+  echo "ブランチ '${BRANCH_NAME}' はすでに存在します。チェックアウトします。"
+  git checkout "$BRANCH_NAME"
+else
+  BASE_BRANCH=$(git remote show origin 2>/dev/null | grep 'HEAD branch' | awk '{print $NF}')
+  BASE_BRANCH="${BASE_BRANCH:-develop}"
+  # develop がなければ main にフォールバック
+  if ! git show-ref --verify --quiet "refs/heads/${BASE_BRANCH}"; then
+    BASE_BRANCH="main"
+  fi
+  echo "ベースブランチ '${BASE_BRANCH}' からブランチを作成します。"
+  git fetch origin "$BASE_BRANCH" --quiet
+  git checkout -b "$BRANCH_NAME" "origin/${BASE_BRANCH}"
+fi
+
+# --- Claude Code 向けコンテキストファイルを生成 ---
+CONTEXT_FILE=".claude/issue-context.md"
+cat > "$CONTEXT_FILE" <<CONTEXT
+# Issue #${ISSUE_NUMBER}: ${TITLE}
+
+## 対応ブランチ
+\`${BRANCH_NAME}\`
+
+## Issue 本文
+${BODY}
+
+## ラベル
+${LABELS}
+
+## Claude Code への作業指示
+
+以下のワークフローで作業してください:
+
+1. **タスク分解**: Issue の内容を具体的な実装タスクに分解し、ユーザーと確認する
+2. **Issue 更新**: 合意したタスクをチェックリスト形式で Issue #${ISSUE_NUMBER} にコメントする
+   \`\`\`bash
+   gh issue comment ${ISSUE_NUMBER} --body "## タスク\n- [ ] ..."
+   \`\`\`
+3. **実装**: タスクをひとつずつ実装し、各タスク完了後にコミットする
+4. **PR 作成**: 全タスク完了後、以下の形式で PR を作成する
+   - ベースブランチ: \`develop\`
+   - 本文に \`Closes #${ISSUE_NUMBER}\` を含める
+CONTEXT
+
+echo ""
+echo "=== 準備完了 ==="
+echo "コンテキストファイル: $CONTEXT_FILE"
+echo ""
+echo "--- Issue 本文 ---"
+echo "$BODY"
+echo "------------------"


### PR DESCRIPTION
## 概要
GitHub Issue を起点に Claude Code が作業できる仕組みを構築しました。

## 変更内容
- `scripts/issue-start.sh` を新規作成: Issue番号を渡すだけでブランチ作成・コンテキスト生成が完了
- `.claude/settings.json`: `gh` コマンドの自動許可を追加
- `CLAUDE.md`: Issue起点ワークフローの手順を Claude Code への指示として追記
- `.gitignore`: `.claude/issue-context.md` を除外

## 使い方
```bash
./scripts/issue-start.sh 42
# → ブランチ作成・.claude/issue-context.md 生成
# → claude を起動してタスク分解・実装・PR作成
```

## 確認事項
- [x] lint エラーなし
- [x] ブランチ名の自動生成（ラベルに応じて prefix 判定）
- [x] `jq` 不要（`gh --template` で代替）
- [x] 未コミット変更があっても `git fetch` + `checkout -b origin/base` で安全に動作

Closes #37