### PR TITLE
feat: ポートフォリオコンテンツをアップデート（プロフィール・スキル・職歴）

### DIFF
--- a/src/components/pages/Home/containers/index.tsx
+++ b/src/components/pages/Home/containers/index.tsx
@@ -58,13 +58,14 @@ export const Home = () => {
               experience, and a total of 5 years including personal projects.
             </Typography>
             <Typography>
-              Currently, I specialize in frontend development, focusing on
-              technologies such as TypeScript, React, and Next.js. My goal is to
-              eventually take on roles as a Tech Lead.
+              I specialize in frontend development with TypeScript, React, and
+              Next.js. My goal is to take on architect and tech lead roles —
+              driving teams through technical excellence.
             </Typography>
             <Typography>
-              I am actively expanding my skill set to include Firebase, AWS, and
-              AI driven development.
+              I am actively expanding into infrastructure (AWS, Firebase) and
+              AI-driven development to strengthen my design capabilities beyond
+              the frontend.
             </Typography>
           </IntroDescription>
           <IconsWrapper>

--- a/src/components/pages/Home/presentations/Experiences/index.tsx
+++ b/src/components/pages/Home/presentations/Experiences/index.tsx
@@ -22,7 +22,7 @@ export const Experiences = () => {
                 My Page renewal project
               </Typography>
               <Typography variant="caption" sx={{ color: "secondary.dark" }}>
-                July 2023 - Present
+                July 2023 - January 2025
               </Typography>
             </TitleWrapper>
           </StepLabel>
@@ -58,7 +58,7 @@ export const Experiences = () => {
                   <Typography>
                     - Fix bugs and improve user experience
                   </Typography>
-                  <Typography>- Frontend system desgin</Typography>
+                  <Typography>- Frontend system design</Typography>
                   <Typography>- Educating junior developers</Typography>
                 </div>
               </div>

--- a/src/components/pages/Home/presentations/Experiences/index.tsx
+++ b/src/components/pages/Home/presentations/Experiences/index.tsx
@@ -15,7 +15,7 @@ export const Experiences = () => {
         Experiences
       </Typography>
       <Stepper orientation="vertical">
-        <Step>
+        <Step expanded>
           <StepLabel>
             <TitleWrapper>
               <Typography variant="h6" sx={{ color: "primary.light" }}>
@@ -65,7 +65,7 @@ export const Experiences = () => {
             </ProjectWrapper>
           </StepContent>
         </Step>
-        <Step>
+        <Step expanded>
           <StepLabel>
             <TitleWrapper>
               <Typography variant="h6" sx={{ color: "primary.light" }}>
@@ -114,7 +114,7 @@ export const Experiences = () => {
             </ProjectWrapper>
           </StepContent>
         </Step>
-        <Step>
+        <Step expanded>
           <StepLabel>
             <TitleWrapper>
               <Typography variant="h6" sx={{ color: "primary.light" }}>

--- a/src/components/pages/Home/presentations/Experiences/index.tsx
+++ b/src/components/pages/Home/presentations/Experiences/index.tsx
@@ -66,6 +66,102 @@ export const Experiences = () => {
           </StepContent>
         </Step>
         <Step>
+          <StepLabel>
+            <TitleWrapper>
+              <Typography variant="h6" sx={{ color: "primary.light" }}>
+                System Risk Response
+              </Typography>
+              <Typography variant="caption" sx={{ color: "secondary.dark" }}>
+                October 2025 - April 2026
+              </Typography>
+            </TitleWrapper>
+          </StepLabel>
+          <StepContent>
+            <ProjectWrapper>
+              <Typography variant="body2">
+                Led a major version upgrade of Next.js (14→16) and migration
+                from Recoil to Jotai. Conducted end-to-end vulnerability
+                assessment using Snyk as a lead engineer.
+              </Typography>
+              <div className="details">
+                <div>
+                  <Typography
+                    sx={{ fontWeight: "bold", color: "primary.main" }}
+                  >
+                    Skill sets:
+                  </Typography>
+                  <Typography>- TypeScript</Typography>
+                  <Typography>- Next.js</Typography>
+                  <Typography>- React</Typography>
+                  <Typography>- Docker</Typography>
+                  <Typography>- AWS</Typography>
+                </div>
+                <div>
+                  <Typography
+                    sx={{ fontWeight: "bold", color: "primary.main" }}
+                  >
+                    Responsibilities:
+                  </Typography>
+                  <Typography>- Technical investigation and PoC</Typography>
+                  <Typography>- Implementation and testing</Typography>
+                  <Typography>- Vulnerability assessment with Snyk</Typography>
+                  <Typography>
+                    - Analysis and remediation of identified vulnerabilities
+                  </Typography>
+                  <Typography>- Lead engineer role</Typography>
+                </div>
+              </div>
+            </ProjectWrapper>
+          </StepContent>
+        </Step>
+        <Step>
+          <StepLabel>
+            <TitleWrapper>
+              <Typography variant="h6" sx={{ color: "primary.light" }}>
+                Development Improvement Project
+              </Typography>
+              <Typography variant="caption" sx={{ color: "secondary.dark" }}>
+                January 2026 - March 2026
+              </Typography>
+            </TitleWrapper>
+          </StepLabel>
+          <StepContent>
+            <ProjectWrapper>
+              <Typography variant="body2">
+                Addressed document quality issues in the MY Page renewal
+                project. Designed an AI-powered automated document checking
+                mechanism and delivered results under limited capacity while
+                managing concurrent projects.
+              </Typography>
+              <div className="details">
+                <div>
+                  <Typography
+                    sx={{ fontWeight: "bold", color: "primary.main" }}
+                  >
+                    Skill sets:
+                  </Typography>
+                  <Typography>- Dify</Typography>
+                  <Typography>- Python</Typography>
+                </div>
+                <div>
+                  <Typography
+                    sx={{ fontWeight: "bold", color: "primary.main" }}
+                  >
+                    Responsibilities:
+                  </Typography>
+                  <Typography>
+                    - Designed AI-based automated document checking
+                  </Typography>
+                  <Typography>
+                    - Created a Python tool to convert Excel to Markdown for AI
+                    readability
+                  </Typography>
+                </div>
+              </div>
+            </ProjectWrapper>
+          </StepContent>
+        </Step>
+        <Step>
           <StepLabel></StepLabel>
         </Step>
       </Stepper>

--- a/src/components/pages/Home/presentations/Experiences/index.tsx
+++ b/src/components/pages/Home/presentations/Experiences/index.tsx
@@ -73,6 +73,7 @@ export const Experiences = () => {
       </Typography>
       <Stepper
         orientation="vertical"
+        nonLinear
         activeStep={activeStepIndex >= 0 ? activeStepIndex : undefined}
       >
         {EXPERIENCES.map(({ isActive: _, ...experience }) => (

--- a/src/components/pages/Home/presentations/Experiences/index.tsx
+++ b/src/components/pages/Home/presentations/Experiences/index.tsx
@@ -6,7 +6,9 @@ import {
 } from "@/components/parts/ExperienceStep";
 import { ExperienceWrapper } from "./styles";
 
-const EXPERIENCES: ExperienceStepProps[] = [
+type ExperienceData = ExperienceStepProps & { isActive?: boolean };
+
+const EXPERIENCES: ExperienceData[] = [
   {
     title: "My Page renewal project",
     period: "July 2023 - January 2025",
@@ -46,16 +48,34 @@ const EXPERIENCES: ExperienceStepProps[] = [
       "Created a Python tool to convert Excel to Markdown for AI readability",
     ],
   },
+  {
+    title: "AI Product Development Standardization",
+    period: "April 2026 - June 2026",
+    description:
+      "Leading standardization of AI-driven application development practices across the team. Providing Claude Code environment and sharing knowledge on AI-assisted development workflows.",
+    skillSets: ["Claude Code", "Docker", "AWS"],
+    responsibilities: [
+      "Creating application development standards assuming AI-driven development",
+      "Providing Claude Code usage environment for the team",
+      "Sharing knowledge and best practices on utilizing Claude Code",
+    ],
+    isActive: true,
+  },
 ];
 
 export const Experiences = () => {
+  const activeStepIndex = EXPERIENCES.findIndex((e) => e.isActive);
+
   return (
     <ExperienceWrapper id="experiences">
       <Typography variant="h3" textAlign="center">
         Experiences
       </Typography>
-      <Stepper orientation="vertical">
-        {EXPERIENCES.map((experience) => (
+      <Stepper
+        orientation="vertical"
+        activeStep={activeStepIndex >= 0 ? activeStepIndex : undefined}
+      >
+        {EXPERIENCES.map(({ isActive: _, ...experience }) => (
           <ExperienceStep key={experience.title} {...experience} />
         ))}
         <Step>

--- a/src/components/pages/Home/presentations/Experiences/styles.ts
+++ b/src/components/pages/Home/presentations/Experiences/styles.ts
@@ -14,33 +14,5 @@ const experienceWrapper = css`
   }
 `;
 
-const projectWrapper = css`
-  margin-left: var(--spacing-4);
-  margin-top: var(--spacing-3);
-
-  .details {
-    display: flex;
-    flex-direction: column;
-    gap: var(--spacing-2);
-    margin-top: var(--spacing-2);
-  }
-
-  /* stylelint-disable-next-line media-query-no-invalid */
-  @media (min-width: ${breakpoint}) {
-    margin-left: var(--spacing-18);
-  }
-`;
-
-const titleWrapper = css`
-  margin-left: var(--spacing-4);
-
-  /* stylelint-disable-next-line media-query-no-invalid */
-  @media (min-width: ${breakpoint}) {
-    margin-left: var(--spacing-18);
-  }
-`;
-
 /** emotion styled components */
 export const ExperienceWrapper = emotionStyled.section`${experienceWrapper}`;
-export const ProjectWrapper = emotionStyled.div`${projectWrapper}`;
-export const TitleWrapper = emotionStyled.div`${titleWrapper}`;

--- a/src/components/pages/Home/presentations/SkillLevel/index.tsx
+++ b/src/components/pages/Home/presentations/SkillLevel/index.tsx
@@ -69,7 +69,7 @@ const SkillLevelSp = () => {
             <CircularProgress
               size={150}
               variant="determinate"
-              value={80}
+              value={85}
               sx={{ color: "info.main" }}
             />
             <Box sx={spCircleBoxSx}>
@@ -82,7 +82,7 @@ const SkillLevelSp = () => {
             <CircularProgress
               size={150}
               variant="determinate"
-              value={75}
+              value={80}
               sx={{ color: "success.light" }}
             />
             <Box sx={spCircleBoxSx}>
@@ -95,7 +95,7 @@ const SkillLevelSp = () => {
             <CircularProgress
               size={150}
               variant="determinate"
-              value={70}
+              value={75}
               sx={{ color: "secondary.dark" }}
             />
             <Box sx={spCircleBoxSx}>
@@ -108,7 +108,7 @@ const SkillLevelSp = () => {
             <CircularProgress
               size={150}
               variant="determinate"
-              value={30}
+              value={40}
               sx={{ color: "info.light" }}
             />
             <Box sx={spCircleBoxSx}>
@@ -158,7 +158,7 @@ const SkillLevelPc = () => {
             <CircularProgress
               size={130}
               variant="determinate"
-              value={80}
+              value={85}
               sx={{ color: "info.dark" }}
             />
             <Box sx={pcCircleBoxSx}>
@@ -171,7 +171,7 @@ const SkillLevelPc = () => {
             <CircularProgress
               size={130}
               variant="determinate"
-              value={75}
+              value={80}
               sx={{ color: "success.light" }}
             />
             <Box sx={pcCircleBoxSx}>
@@ -184,7 +184,7 @@ const SkillLevelPc = () => {
             <CircularProgress
               size={130}
               variant="determinate"
-              value={70}
+              value={75}
               sx={{ color: "secondary.dark" }}
             />
             <Box sx={pcCircleBoxSx}>
@@ -197,7 +197,7 @@ const SkillLevelPc = () => {
             <CircularProgress
               size={130}
               variant="determinate"
-              value={30}
+              value={40}
               sx={{ color: "info.light" }}
             />
             <Box sx={pcCircleBoxSx}>

--- a/src/components/parts/ExperienceStep/index.stories.tsx
+++ b/src/components/parts/ExperienceStep/index.stories.tsx
@@ -51,6 +51,21 @@ export const SystemRiskResponse: Story = {
   },
 };
 
+export const AiProductDevelopmentStandardization: Story = {
+  args: {
+    title: "AI Product Development Standardization",
+    period: "April 2026 - June 2026",
+    description:
+      "Leading standardization of AI-driven application development practices across the team. Providing Claude Code environment and sharing knowledge on AI-assisted development workflows.",
+    skillSets: ["Claude Code", "Docker", "AWS"],
+    responsibilities: [
+      "Creating application development standards assuming AI-driven development",
+      "Providing Claude Code usage environment for the team",
+      "Sharing knowledge and best practices on utilizing Claude Code",
+    ],
+  },
+};
+
 export const DevelopmentImprovementProject: Story = {
   args: {
     title: "Development Improvement Project",

--- a/src/components/parts/ExperienceStep/index.stories.tsx
+++ b/src/components/parts/ExperienceStep/index.stories.tsx
@@ -1,13 +1,24 @@
-import { Step, StepLabel, Stepper, Typography } from "@mui/material";
+import { Stepper } from "@mui/material";
 import React from "react";
-import {
-  ExperienceStep,
-  type ExperienceStepProps,
-} from "@/components/parts/ExperienceStep";
-import { ExperienceWrapper } from "./styles";
+import { ExperienceStep } from ".";
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
 
-const EXPERIENCES: ExperienceStepProps[] = [
-  {
+const meta: Meta<typeof ExperienceStep> = {
+  component: ExperienceStep,
+  decorators: [
+    (Story) => (
+      <Stepper orientation="vertical">
+        <Story />
+      </Stepper>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof ExperienceStep>;
+
+export const Default: Story = {
+  args: {
     title: "My Page renewal project",
     period: "July 2023 - January 2025",
     description:
@@ -21,7 +32,10 @@ const EXPERIENCES: ExperienceStepProps[] = [
       "Educating junior developers",
     ],
   },
-  {
+};
+
+export const SystemRiskResponse: Story = {
+  args: {
     title: "System Risk Response",
     period: "October 2025 - April 2026",
     description:
@@ -35,7 +49,10 @@ const EXPERIENCES: ExperienceStepProps[] = [
       "Lead engineer role",
     ],
   },
-  {
+};
+
+export const DevelopmentImprovementProject: Story = {
+  args: {
     title: "Development Improvement Project",
     period: "January 2026 - March 2026",
     description:
@@ -46,22 +63,4 @@ const EXPERIENCES: ExperienceStepProps[] = [
       "Created a Python tool to convert Excel to Markdown for AI readability",
     ],
   },
-];
-
-export const Experiences = () => {
-  return (
-    <ExperienceWrapper id="experiences">
-      <Typography variant="h3" textAlign="center">
-        Experiences
-      </Typography>
-      <Stepper orientation="vertical">
-        {EXPERIENCES.map((experience) => (
-          <ExperienceStep key={experience.title} {...experience} />
-        ))}
-        <Step>
-          <StepLabel />
-        </Step>
-      </Stepper>
-    </ExperienceWrapper>
-  );
 };

--- a/src/components/parts/ExperienceStep/index.tsx
+++ b/src/components/parts/ExperienceStep/index.tsx
@@ -1,0 +1,57 @@
+import { Step, StepContent, StepLabel, Typography } from "@mui/material";
+import React from "react";
+import { ProjectWrapper, TitleWrapper } from "./styles";
+
+export type ExperienceStepProps = {
+  title: string;
+  period: string;
+  description: string;
+  skillSets: string[];
+  responsibilities: string[];
+};
+
+export const ExperienceStep = ({
+  title,
+  period,
+  description,
+  skillSets,
+  responsibilities,
+}: ExperienceStepProps) => {
+  return (
+    <Step expanded>
+      <StepLabel>
+        <TitleWrapper>
+          <Typography variant="h6" sx={{ color: "primary.light" }}>
+            {title}
+          </Typography>
+          <Typography variant="caption" sx={{ color: "secondary.dark" }}>
+            {period}
+          </Typography>
+        </TitleWrapper>
+      </StepLabel>
+      <StepContent>
+        <ProjectWrapper>
+          <Typography variant="body2">{description}</Typography>
+          <div className="details">
+            <div>
+              <Typography sx={{ fontWeight: "bold", color: "primary.main" }}>
+                Skill sets:
+              </Typography>
+              {skillSets.map((skill) => (
+                <Typography key={skill}>- {skill}</Typography>
+              ))}
+            </div>
+            <div>
+              <Typography sx={{ fontWeight: "bold", color: "primary.main" }}>
+                Responsibilities:
+              </Typography>
+              {responsibilities.map((resp) => (
+                <Typography key={resp}>- {resp}</Typography>
+              ))}
+            </div>
+          </div>
+        </ProjectWrapper>
+      </StepContent>
+    </Step>
+  );
+};

--- a/src/components/parts/ExperienceStep/index.tsx
+++ b/src/components/parts/ExperienceStep/index.tsx
@@ -1,4 +1,10 @@
-import { Step, StepContent, StepLabel, Typography } from "@mui/material";
+import {
+  Step,
+  StepContent,
+  StepLabel,
+  type StepProps,
+  Typography,
+} from "@mui/material";
 import React from "react";
 import { ProjectWrapper, TitleWrapper } from "./styles";
 
@@ -16,9 +22,10 @@ export const ExperienceStep = ({
   description,
   skillSets,
   responsibilities,
-}: ExperienceStepProps) => {
+  ...stepProps
+}: ExperienceStepProps & StepProps) => {
   return (
-    <Step expanded>
+    <Step expanded {...stepProps}>
       <StepLabel>
         <TitleWrapper>
           <Typography variant="h6" sx={{ color: "primary.light" }}>

--- a/src/components/parts/ExperienceStep/styles.ts
+++ b/src/components/parts/ExperienceStep/styles.ts
@@ -1,0 +1,32 @@
+import { css } from "@emotion/react";
+import emotionStyled from "@emotion/styled";
+import { breakpoint } from "@/assets/styles/variable";
+
+const projectWrapper = css`
+  margin-left: var(--spacing-4);
+  margin-top: var(--spacing-3);
+
+  .details {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-2);
+    margin-top: var(--spacing-2);
+  }
+
+  /* stylelint-disable-next-line media-query-no-invalid */
+  @media (min-width: ${breakpoint}) {
+    margin-left: var(--spacing-18);
+  }
+`;
+
+const titleWrapper = css`
+  margin-left: var(--spacing-4);
+
+  /* stylelint-disable-next-line media-query-no-invalid */
+  @media (min-width: ${breakpoint}) {
+    margin-left: var(--spacing-18);
+  }
+`;
+
+export const ProjectWrapper = emotionStyled.div`${projectWrapper}`;
+export const TitleWrapper = emotionStyled.div`${titleWrapper}`;


### PR DESCRIPTION
## 概要

プロフィール文・スキルレベル・職歴を最新の情報にアップデート。あわせて Experiences セクションを `ExperienceStep` コンポーネントとしてリファクタリングし、Storybook も整備した。

## 対応 Issue

Closes #46

## 変更内容

- プロフィール文をアーキテクト・テックリード志向に更新（インフラ・AI設計力への拡張を明記）
- スキルレベル更新: TypeScript 85%, React 80%, Next.js 75%, Docker 40%
- 職歴追加: System Risk Response（2025/10〜2026/4）
- 職歴追加: Development Improvement Project（2026/1〜2026/3）
- 職歴追加: AI Product Development Standardization（2026/4〜2026/6、進行中）
- My Page renewal project の期間を 2023/7〜2025/1 に修正
- `ExperienceStep` を `components/parts/` 配下にコンポーネント化
- Storybook ストーリーを全プロジェクト分追加
- `nonLinear` Stepper で過去プロジェクトをチェックマークではなく番号で表示
- 進行中プロジェクト（isActive）をアクティブカラーでハイライト

## 確認事項

- [x] 型エラーなし (`npx tsc --noEmit`)
- [x] lint: husky の lint-staged がコミット時に確認済み
- [x] Playwright によるリグレッションテスト実施済み（全セクション目視確認）
- [x] build: CI で確認