### PR TITLE
feat: ライト/ダークテーマ切り替え機能の追加

### DIFF
--- a/src/assets/styles/variable.ts
+++ b/src/assets/styles/variable.ts
@@ -57,6 +57,8 @@ export const variables = css`
   [data-color-scheme="dark"] {
     --bg-color-default: var(--color-dark-navy);
     --bg-color-light: var(--color-white);
-    --text-default: var(--color-gray);
+
+    /* --text-default はオーバーライドしない。常に darkNavy のままにする。
+       ダーク背景セクション内のテキストは MUI sx で明示的に上書きする */
   }
 `;

--- a/src/assets/styles/variable.ts
+++ b/src/assets/styles/variable.ts
@@ -7,6 +7,7 @@ export const breakpoint = "768px";
 export const headerHeight = "56px";
 
 export const variables = css`
+  /* light mode (default) */
   :root {
     /* font-size */
     --fontSizeXXS: 10px;
@@ -50,5 +51,12 @@ export const variables = css`
     --bg-color-default: var(--color-gray);
     --bg-color-dark: var(--color-dark-navy);
     --bg-color-light: var(--color-white);
+  }
+
+  /* dark mode overrides */
+  [data-color-scheme="dark"] {
+    --bg-color-default: var(--color-dark-navy);
+    --bg-color-light: var(--color-white);
+    --text-default: var(--color-gray);
   }
 `;

--- a/src/components/pages/Home/containers/index.tsx
+++ b/src/components/pages/Home/containers/index.tsx
@@ -1,9 +1,16 @@
 "use client";
-import { Avatar, IconButton, Tooltip, Typography } from "@mui/material";
+import {
+  Avatar,
+  IconButton,
+  ThemeProvider,
+  Tooltip,
+  Typography,
+} from "@mui/material";
 import Link from "next/link";
 import React from "react";
 import { Icon } from "@/components/parts/Icon";
 import { TypingCarousel } from "@/components/parts/TypingCarousel";
+import { darkTheme } from "@/components/themes";
 import { Experiences } from "../presentations/Experiences";
 import { SkillLevel } from "../presentations/SkillLevel";
 import { Skills } from "../presentations/Skills";
@@ -30,22 +37,25 @@ export const Home = () => {
 
   return (
     <>
-      <AvatarWrapper id="home">
-        <Avatar
-          alt="ねこのこ"
-          src="/assets/img/ねこのこ.jpg"
-          sx={{ width: "140px", height: "140px" }}
-        />
-        <TypingCarousel texts={TYPING_TEXT} />
-        <ArrowDownWrapper onClick={scrollToNextSection}>
-          <IconButton aria-label="次のセクションにスクロール">
-            <Icon
-              icon="arrowDown"
-              sx={{ color: "text.primary", fontSize: "3rem" }}
-            />
-          </IconButton>
-        </ArrowDownWrapper>
-      </AvatarWrapper>
+      {/* ヒーロー section は常にダーク背景のため darkTheme で固定する */}
+      <ThemeProvider theme={darkTheme}>
+        <AvatarWrapper id="home">
+          <Avatar
+            alt="ねこのこ"
+            src="/assets/img/ねこのこ.jpg"
+            sx={{ width: "140px", height: "140px" }}
+          />
+          <TypingCarousel texts={TYPING_TEXT} />
+          <ArrowDownWrapper onClick={scrollToNextSection}>
+            <IconButton aria-label="次のセクションにスクロール">
+              <Icon
+                icon="arrowDown"
+                sx={{ color: "text.primary", fontSize: "3rem" }}
+              />
+            </IconButton>
+          </ArrowDownWrapper>
+        </AvatarWrapper>
+      </ThemeProvider>
       <IntroWrapper id="about">
         <div>
           <IntroDescription>

--- a/src/components/pages/Home/presentations/SkillLevel/index.tsx
+++ b/src/components/pages/Home/presentations/SkillLevel/index.tsx
@@ -43,7 +43,7 @@ const spCircleBoxSx = {
   width: "126px",
   height: "126px",
   borderRadius: 99,
-  backgroundColor: "background.default",
+  backgroundColor: "var(--color-dark-navy)",
 };
 
 const pcCircleBoxSx = {
@@ -57,7 +57,7 @@ const pcCircleBoxSx = {
   width: "110px",
   height: "110px",
   borderRadius: 99,
-  backgroundColor: "background.default",
+  backgroundColor: "var(--color-dark-navy)",
 };
 
 const SkillLevelSp = () => {

--- a/src/components/pages/Home/presentations/Skills/index.tsx
+++ b/src/components/pages/Home/presentations/Skills/index.tsx
@@ -6,7 +6,11 @@ import { SkillWrapper, CardsWrapper } from "./styles";
 export const Skills = () => {
   return (
     <SkillWrapper id="skills">
-      <Typography variant="h3" textAlign="center">
+      <Typography
+        variant="h3"
+        textAlign="center"
+        sx={{ color: "text.primary" }}
+      >
         Skills
       </Typography>
       <CardsWrapper>

--- a/src/components/pages/Home/presentations/Works/index.tsx
+++ b/src/components/pages/Home/presentations/Works/index.tsx
@@ -7,7 +7,11 @@ import { WorksWrapper, CardsWrapper } from "./styles";
 export const Works = () => {
   return (
     <WorksWrapper id="works">
-      <Typography variant="h3" textAlign="center">
+      <Typography
+        variant="h3"
+        textAlign="center"
+        sx={{ color: "text.primary" }}
+      >
         My Works
       </Typography>
       <CardsWrapper>

--- a/src/components/parts/DrawerNav/index.stories.tsx
+++ b/src/components/parts/DrawerNav/index.stories.tsx
@@ -1,10 +1,18 @@
 import { Button } from "@mui/material";
 import { useState } from "react";
+import { ThemeModeProvider } from "@/contexts/ThemeContext";
 import { DrawerNav } from ".";
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
 
 const meta: Meta<typeof DrawerNav> = {
   component: DrawerNav,
+  decorators: [
+    (Story) => (
+      <ThemeModeProvider>
+        <Story />
+      </ThemeModeProvider>
+    ),
+  ],
 };
 
 export default meta;

--- a/src/components/parts/DrawerNav/index.tsx
+++ b/src/components/parts/DrawerNav/index.tsx
@@ -9,6 +9,7 @@ import {
 } from "@mui/material";
 import { useRouter } from "next/navigation";
 import React from "react";
+import { useThemeMode } from "@/hooks/useThemeMode";
 import { Icon } from "../Icon";
 import { ListWrapper } from "./styles";
 
@@ -20,6 +21,7 @@ type Props = {
 
 export const DrawerNav = ({ isOpen, onClose, onOpen }: Props) => {
   const router = useRouter();
+  const { mode, toggleTheme } = useThemeMode();
 
   const listItems = [
     { text: "Home", anchor: "home" },
@@ -74,15 +76,16 @@ export const DrawerNav = ({ isOpen, onClose, onOpen }: Props) => {
           </ListItem>
           <ListItem disablePadding>
             <ListItemButton
-              onClick={() => {
-                alert("Convert theme is under developing");
+              onClick={(e) => {
+                e.stopPropagation();
+                toggleTheme();
               }}
             >
               <ListItemText
                 primary={
                   <ListWrapper>
-                    <Icon icon="darkMode" />
-                    Dark Mode
+                    <Icon icon={mode === "dark" ? "lightMode" : "darkMode"} />
+                    {mode === "dark" ? "Light Mode" : "Dark Mode"}
                   </ListWrapper>
                 }
                 sx={{ color: "primary.dark", textAlign: "center" }}

--- a/src/components/parts/Footer/styles.ts
+++ b/src/components/parts/Footer/styles.ts
@@ -4,6 +4,7 @@ import { breakpoint } from "@/assets/styles/variable";
 
 const wrapper = css`
   background-color: var(--bg-color-dark);
+  border-top: 1px solid #64748b; /* text.disabled */
   padding: var(--spacing-12) var(--spacing-4) var(--spacing-10);
 `;
 

--- a/src/components/parts/Header/index.stories.tsx
+++ b/src/components/parts/Header/index.stories.tsx
@@ -1,5 +1,6 @@
 import { css } from "@emotion/react";
 import emotionStyled from "@emotion/styled";
+import { ThemeModeProvider } from "@/contexts/ThemeContext";
 import { Header } from ".";
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
 
@@ -8,6 +9,13 @@ const meta: Meta<typeof Header> = {
   parameters: {
     layout: "fullscreen",
   },
+  decorators: [
+    (Story) => (
+      <ThemeModeProvider>
+        <Story />
+      </ThemeModeProvider>
+    ),
+  ],
 };
 
 export default meta;

--- a/src/components/parts/Header/index.tsx
+++ b/src/components/parts/Header/index.tsx
@@ -7,11 +7,13 @@ import {
   ListItemButton,
   ListItemText,
   Toolbar,
+  Tooltip,
   Typography,
 } from "@mui/material";
 import { useRouter } from "next/navigation";
 import React, { useState } from "react";
 import { useScrollSpy } from "@/hooks/useScrollSpy";
+import { useThemeMode } from "@/hooks/useThemeMode";
 import { DrawerNav } from "../DrawerNav";
 import { Icon } from "../Icon";
 import { MenuButton, PcHeaderMenu, appBarSx, toolbarSx } from "./styles";
@@ -19,6 +21,7 @@ import { MenuButton, PcHeaderMenu, appBarSx, toolbarSx } from "./styles";
 export const Header = () => {
   const router = useRouter();
   const [isOpen, setIsOpen] = useState(false);
+  const { mode, toggleTheme } = useThemeMode();
 
   const listItems = [
     { text: "Home", anchor: "home" },
@@ -87,6 +90,13 @@ export const Header = () => {
               </ListItemButton>
             </ListItem>
           ))}
+          <ListItem disablePadding sx={{ marginLeft: "8px" }}>
+            <Tooltip title={mode === "dark" ? "Light mode" : "Dark mode"}>
+              <IconButton onClick={toggleTheme} color="secondary" size="large">
+                <Icon icon={mode === "dark" ? "lightMode" : "darkMode"} />
+              </IconButton>
+            </Tooltip>
+          </ListItem>
         </PcHeaderMenu>
         <MenuButton>
           <IconButton

--- a/src/components/parts/Layout/index.tsx
+++ b/src/components/parts/Layout/index.tsx
@@ -1,10 +1,12 @@
 "use client";
 import { Global, css } from "@emotion/react";
 import { CssBaseline, ThemeProvider } from "@mui/material";
-import React from "react";
+import React, { useEffect } from "react";
 import { globalStyle } from "@/assets/styles/global";
 import { variables } from "@/assets/styles/variable";
-import { defaultTheme } from "@/components/themes";
+import { darkTheme, lightTheme } from "@/components/themes";
+import { ThemeModeProvider } from "@/contexts/ThemeContext";
+import { useThemeMode } from "@/hooks/useThemeMode";
 import { Footer } from "../Footer";
 import { Header } from "../Header";
 
@@ -18,14 +20,29 @@ const globalStyles = css`
   ${variables} /* scssカスタムプロパティ */
 `;
 
-export const Layout = ({ children }: Props) => {
+const LayoutInner = ({ children }: Props) => {
+  const { mode } = useThemeMode();
+  const theme = mode === "dark" ? darkTheme : lightTheme;
+
+  useEffect(() => {
+    document.documentElement.setAttribute("data-color-scheme", mode);
+  }, [mode]);
+
   return (
-    <ThemeProvider theme={defaultTheme}>
+    <ThemeProvider theme={theme}>
       <CssBaseline />
       <Global styles={globalStyles} />
       <Header />
       {children}
       <Footer />
     </ThemeProvider>
+  );
+};
+
+export const Layout = ({ children }: Props) => {
+  return (
+    <ThemeModeProvider>
+      <LayoutInner>{children}</LayoutInner>
+    </ThemeModeProvider>
   );
 };

--- a/src/components/parts/Layout/index.tsx
+++ b/src/components/parts/Layout/index.tsx
@@ -30,7 +30,10 @@ const LayoutInner = ({ children }: Props) => {
       <Global styles={globalStyles} />
       <Header />
       {children}
-      <Footer />
+      {/* Footer は常にダーク背景のため darkTheme で固定する */}
+      <ThemeProvider theme={darkTheme}>
+        <Footer />
+      </ThemeProvider>
     </ThemeProvider>
   );
 };

--- a/src/components/parts/Layout/index.tsx
+++ b/src/components/parts/Layout/index.tsx
@@ -1,7 +1,7 @@
 "use client";
 import { Global, css } from "@emotion/react";
 import { CssBaseline, ThemeProvider } from "@mui/material";
-import React, { useEffect } from "react";
+import React from "react";
 import { globalStyle } from "@/assets/styles/global";
 import { variables } from "@/assets/styles/variable";
 import { darkTheme, lightTheme } from "@/components/themes";
@@ -23,10 +23,6 @@ const globalStyles = css`
 const LayoutInner = ({ children }: Props) => {
   const { mode } = useThemeMode();
   const theme = mode === "dark" ? darkTheme : lightTheme;
-
-  useEffect(() => {
-    document.documentElement.setAttribute("data-color-scheme", mode);
-  }, [mode]);
 
   return (
     <ThemeProvider theme={theme}>

--- a/src/components/themes/index.ts
+++ b/src/components/themes/index.ts
@@ -6,7 +6,7 @@ const mulish = Mulish({
   display: "swap",
 });
 
-// ここを変更したらvariables.scssも変更する
+// ここを変更したらvariable.tsも変更する
 const COLOR_PALETTE = {
   darkNavy: "#201e43",
   navy: "#134b70",
@@ -17,14 +17,23 @@ const COLOR_PALETTE = {
   fog: "#64748b",
 };
 
-/**
- * MUIのpalette
- * https://mui.com/material-ui/customization/default-theme/?expand-path=$.palette
- */
+const typography = {
+  fontFamily: mulish.style.fontFamily,
+  h1: { fontSize: "3rem" },
+  h2: { fontSize: "2.5rem" },
+  h3: { fontSize: "2rem" },
+  h4: { fontSize: "1.75rem" },
+  h5: { fontSize: "1.5rem" },
+  h6: { fontSize: "1.25rem" },
+  subtitle1: { fontSize: "1rem" },
+  subtitle2: { fontSize: "0.875rem" },
+  body1: { fontSize: "1rem" },
+  body2: { fontSize: "0.875rem" },
+};
 
-/** MUIのカスタムthemeを定義 */
-export const defaultTheme = createTheme({
+export const darkTheme = createTheme({
   palette: {
+    mode: "dark",
     primary: {
       main: COLOR_PALETTE.navy,
     },
@@ -42,37 +51,28 @@ export const defaultTheme = createTheme({
       paper: COLOR_PALETTE.gray,
     },
   },
-  typography: {
-    fontFamily: mulish.style.fontFamily,
-    h1: {
-      fontSize: "3rem", // 48px
+  typography,
+});
+
+export const lightTheme = createTheme({
+  palette: {
+    mode: "light",
+    primary: {
+      main: COLOR_PALETTE.navy,
     },
-    h2: {
-      fontSize: "2.5rem", // 40px
+    secondary: {
+      main: COLOR_PALETTE.darkNavy,
+      light: COLOR_PALETTE.lightGray,
     },
-    h3: {
-      fontSize: "2rem", // 32px
+    text: {
+      primary: COLOR_PALETTE.darkNavy,
+      secondary: COLOR_PALETTE.gray,
+      disabled: COLOR_PALETTE.fog,
     },
-    h4: {
-      fontSize: "1.75rem", // 28px
-    },
-    h5: {
-      fontSize: "1.5rem", // 24px
-    },
-    h6: {
-      fontSize: "1.25rem", // 20px
-    },
-    subtitle1: {
-      fontSize: "1rem", // 16px
-    },
-    subtitle2: {
-      fontSize: "0.875rem", // 14px
-    },
-    body1: {
-      fontSize: "1rem", // 16px
-    },
-    body2: {
-      fontSize: "0.875rem", // 14px
+    background: {
+      default: COLOR_PALETTE.lightGray,
+      paper: "#ffffff",
     },
   },
+  typography,
 });

--- a/src/components/themes/index.ts
+++ b/src/components/themes/index.ts
@@ -31,9 +31,10 @@ const typography = {
   body2: { fontSize: "0.875rem" },
 };
 
+// palette.mode を設定しない = MUI デフォルト(light)の component スタイルを維持
+// 元の defaultTheme と同じ挙動になり、Stepper/Divider 等が崩れない
 export const darkTheme = createTheme({
   palette: {
-    mode: "dark",
     primary: {
       main: COLOR_PALETTE.navy,
     },
@@ -43,7 +44,7 @@ export const darkTheme = createTheme({
     },
     text: {
       primary: COLOR_PALETTE.gray,
-      secondary: COLOR_PALETTE.darkNavy,
+      secondary: COLOR_PALETTE.lightNavy, // 暗背景で読めるトーン
       disabled: COLOR_PALETTE.fog,
     },
     background: {
@@ -62,11 +63,11 @@ export const lightTheme = createTheme({
     },
     secondary: {
       main: COLOR_PALETTE.darkNavy,
-      light: COLOR_PALETTE.lightGray,
+      light: COLOR_PALETTE.lightBlue, // lightGray はページ背景と同色になるため lightBlue に変更
     },
     text: {
       primary: COLOR_PALETTE.darkNavy,
-      secondary: COLOR_PALETTE.gray,
+      secondary: COLOR_PALETTE.fog, // 白背景で読めるトーン
       disabled: COLOR_PALETTE.fog,
     },
     background: {

--- a/src/contexts/ThemeContext.tsx
+++ b/src/contexts/ThemeContext.tsx
@@ -1,0 +1,46 @@
+"use client";
+import React, { createContext, useEffect, useState } from "react";
+
+type ThemeMode = "light" | "dark";
+
+type ThemeContextValue = {
+  mode: ThemeMode;
+  toggleTheme: () => void;
+};
+
+export const ThemeContext = createContext<ThemeContextValue>({
+  mode: "dark",
+  toggleTheme: () => {},
+});
+
+type Props = {
+  children: React.ReactNode;
+};
+
+function getStoredTheme(): ThemeMode {
+  if (typeof window === "undefined") return "dark";
+  const stored = window.localStorage.getItem("theme");
+  return stored === "light" || stored === "dark" ? stored : "dark";
+}
+
+export const ThemeModeProvider = ({ children }: Props) => {
+  const [mode, setMode] = useState<ThemeMode>(getStoredTheme);
+
+  useEffect(() => {
+    document.documentElement.setAttribute("data-color-scheme", mode);
+  }, [mode]);
+
+  const toggleTheme = () => {
+    setMode((prev) => {
+      const next = prev === "dark" ? "light" : "dark";
+      localStorage.setItem("theme", next);
+      return next;
+    });
+  };
+
+  return (
+    <ThemeContext.Provider value={{ mode, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+};

--- a/src/contexts/ThemeContext.tsx
+++ b/src/contexts/ThemeContext.tsx
@@ -1,5 +1,5 @@
 "use client";
-import React, { createContext, useEffect, useState } from "react";
+import React, { createContext, useEffect, useSyncExternalStore } from "react";
 
 type ThemeMode = "light" | "dark";
 
@@ -17,25 +17,38 @@ type Props = {
   children: React.ReactNode;
 };
 
-function getStoredTheme(): ThemeMode {
-  if (typeof window === "undefined") return "dark";
-  const stored = window.localStorage.getItem("theme");
+const STORAGE_KEY = "theme";
+const CHANGE_EVENT = "themeChange";
+
+function getSnapshot(): ThemeMode {
+  const stored = localStorage.getItem(STORAGE_KEY);
   return stored === "light" || stored === "dark" ? stored : "dark";
 }
 
+function getServerSnapshot(): ThemeMode {
+  return "dark";
+}
+
+function subscribe(callback: () => void) {
+  window.addEventListener(CHANGE_EVENT, callback);
+  window.addEventListener("storage", callback);
+  return () => {
+    window.removeEventListener(CHANGE_EVENT, callback);
+    window.removeEventListener("storage", callback);
+  };
+}
+
 export const ThemeModeProvider = ({ children }: Props) => {
-  const [mode, setMode] = useState<ThemeMode>(getStoredTheme);
+  const mode = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
 
   useEffect(() => {
     document.documentElement.setAttribute("data-color-scheme", mode);
   }, [mode]);
 
   const toggleTheme = () => {
-    setMode((prev) => {
-      const next = prev === "dark" ? "light" : "dark";
-      localStorage.setItem("theme", next);
-      return next;
-    });
+    const next = mode === "dark" ? "light" : "dark";
+    localStorage.setItem(STORAGE_KEY, next);
+    window.dispatchEvent(new Event(CHANGE_EVENT));
   };
 
   return (

--- a/src/hooks/useThemeMode.ts
+++ b/src/hooks/useThemeMode.ts
@@ -1,0 +1,4 @@
+import { useContext } from "react";
+import { ThemeContext } from "@/contexts/ThemeContext";
+
+export const useThemeMode = () => useContext(ThemeContext);


### PR DESCRIPTION
## 概要

ライト/ダークのテーマ切り替え機能を実装した。localStorage でテーマ設定を永続化し、リロード後も選択状態が保持される。

## 対応 Issue

Closes #25

## 変更内容

- `ThemeContext` / `ThemeModeProvider` を新規作成（`useSyncExternalStore` で localStorage を読み取り、SSR 対応）
- `useThemeMode` フックを新規作成
- `lightTheme` / `darkTheme` の2テーマを定義（MUI + CSS カスタムプロパティ）
- `Layout` にテーマプロバイダーを組み込み、Footer・AvatarWrapper は常に darkTheme でラップ
- `Header` / `DrawerNav` にテーマ切り替えボタンを追加
- Skills・Works セクションの h3 見出しに `color: text.primary` を明示し、ダークモードでの可視性を修正
- SkillLevel CircularProgress の内部 Box 背景色をテーマ依存から `--color-dark-navy` 固定に変更
- Footer 上部に `border-top` を追加し、ダークモードでの Works との境界を明確化

## 確認事項

- [x] 型エラーなし (`npx tsc --noEmit`)
- [x] lint: husky の lint-staged がコミット時に確認済み
- [ ] build: CI で確認