### PR TITLE
chore: ブランチ戦略を main/作業ブランチに変更

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -23,7 +23,7 @@
       "Bash(npm run lint)",
       "Bash(npm run build)",
       "Bash(git push --force*)",
-      "Bash(git push origin develop*)",
+      "Bash(git push origin main)",
       "Bash(git reset --hard*)"
     ]
   },

--- a/.claude/skills/plan/SKILL.md
+++ b/.claude/skills/plan/SKILL.md
@@ -14,7 +14,7 @@ description: Issue を解析して実装タスクをチェックリスト化し�
    ```bash
    gh issue comment <番号> --body "## タスク\n- [ ] ..."
    ```
-6. 現在のブランチが `develop` であれば `./scripts/issue-start.sh <番号>` でブランチを作成する。すでに作業ブランチにいる場合はスキップする。
+6. 現在のブランチが `main` であれば `./scripts/issue-start.sh <番号>` でブランチを作成する。すでに作業ブランチにいる場合はスキップする。
 
 ## サブエージェント戦略
 

--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -7,13 +7,13 @@ description: lint・ビルド確認後、develop への PR をテンプレート
 ## 手順
 
 1. `.claude/issue-context.md` から Issue 番号・ブランチ名を読み取る。
-2. `git log develop..HEAD --oneline` で変更コミットを確認する。
+2. `git log main..HEAD --oneline` で変更コミットを確認する。
 3. `npx tsc --noEmit` を実行して型エラーがないことを確認する。
 4. 以下のテンプレートで PR を作成する:
    - lint は husky の lint-staged がコミット時に実行済み
    - build の最終確認は CI に委ねる
    ```bash
-   gh pr create --base develop --head <ブランチ名> --title "<タイトル>" --body "..."
+   gh pr create --base main --head <ブランチ名> --title "<タイトル>" --body "..."
    ```
 
 ## PR テンプレート
@@ -45,6 +45,6 @@ Closes #<番号>
 
 ## 注意
 
-- PR のベースブランチは必ず `develop`（`main` への直接 PR は禁止）
+- PR のベースブランチは必ず `main`
 - タイトルは Conventional Commits に準じる形式（`feat:`, `fix:` など）
 - `Closes #番号` を本文に含めること

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,11 +76,10 @@ npm run build-storybook # Storybook ビルド
 
 ## Git ワークフロー
 
-- `main`: プロダクションブランチ
-- `develop`: 開発ブランチ（PR のベースブランチ）
+- `main`: プロダクションブランチ（PR のベースブランチ）
 - 作業ブランチ: `feature/<name>`, `fix/<name>`, `chore/<name>` などの形式
 
-**`develop` への直接コミット・push は禁止。** 作業は必ず Issue 起点でブランチを切ってから開始すること。
+**`main` への直接コミット・push は禁止。** 作業は必ず Issue 起点でブランチを切ってから開始すること。
 
 ## Issue 起点の開発ワークフロー
 
@@ -112,7 +111,7 @@ npm run build-storybook # Storybook ビルド
 | `/plan` | Issue を解析してタスクをチェックリスト化し、Issue にコメント投稿する | `/plan 43` or `/plan`（context から自動取得） |
 | `/implement` | タスクリストをもとに実装を進め、各タスク完了後にコミットする | `/implement` or `/implement hook` |
 | `/test` | テスト観点を列挙してテストコードを作成する | `/test src/hooks/useFoo.ts` |
-| `/pr` | lint・ビルド確認後、`develop` への PR をテンプレートに従って作成する | `/pr` |
+| `/pr` | lint・ビルド確認後、`main` への PR をテンプレートに従って作成する | `/pr` |
 
 ### 推奨ワークフロー
 

--- a/scripts/issue-start.sh
+++ b/scripts/issue-start.sh
@@ -66,12 +66,7 @@ if git show-ref --verify --quiet "refs/heads/${BRANCH_NAME}"; then
   echo "ブランチ '${BRANCH_NAME}' はすでに存在します。チェックアウトします。"
   git checkout "$BRANCH_NAME"
 else
-  BASE_BRANCH=$(git remote show origin 2>/dev/null | grep 'HEAD branch' | awk '{print $NF}')
-  BASE_BRANCH="${BASE_BRANCH:-develop}"
-  # develop がなければ main にフォールバック
-  if ! git show-ref --verify --quiet "refs/heads/${BASE_BRANCH}"; then
-    BASE_BRANCH="main"
-  fi
+  BASE_BRANCH="main"
   echo "ベースブランチ '${BASE_BRANCH}' からブランチを作成します。"
   git fetch origin "$BASE_BRANCH" --quiet
   git checkout -b "$BRANCH_NAME" "origin/${BASE_BRANCH}"
@@ -102,7 +97,7 @@ ${LABELS}
    \`\`\`
 3. **実装**: タスクをひとつずつ実装し、各タスク完了後にコミットする
 4. **PR 作成**: 全タスク完了後、以下の形式で PR を作成する
-   - ベースブランチ: \`develop\`
+   - ベースブランチ: \`main\`
    - 本文に \`Closes #${ISSUE_NUMBER}\` を含める
 CONTEXT
 


### PR DESCRIPTION
## 概要

develop ブランチを廃止し、`main` + 作業ブランチのシンプルな構成に移行する。

## 対応 Issue

Closes #60

## 変更内容

- `CLAUDE.md`: Git ワークフローセクションを更新（develop → main）
- `scripts/issue-start.sh`: `BASE_BRANCH` を `main` に固定（develop へのフォールバック削除）
- `.claude/settings.json`: deny ルールを `git push origin main` に変更
- `.claude/skills/plan/SKILL.md`: main ブランチチェックに更新
- `.claude/skills/pr/SKILL.md`: PR ベースブランチを main に変更

## 確認事項

- [ ] 型エラーなし (`npx tsc --noEmit`)
- [ ] lint: husky の lint-staged がコミット時に確認済み
- [ ] build: CI で確認

## マージ後の追加作業（手動）

1. このブランチ → develop → main の順でマージ
2. GitHub のデフォルトブランチを `main` に変更: Settings → Branches → Default branch
3. `develop` ブランチを削除