### PR TITLE
feat: add AI Radar to My Works

### DIFF
--- a/src/components/pages/Home/containers/constants.ts
+++ b/src/components/pages/Home/containers/constants.ts
@@ -5,6 +5,8 @@ export const URL = {
   STUDY_TRACKER: "https://study-tracker.shunniehub.com",
   STUDY_TRACKER_REPO: "https://github.com/Shunnie816/study-tracker-next",
   STUDY_TRACKER_ZENN: "https://zenn.dev/nekonoko2323/articles/795d624f3293c7",
+  AI_RADAR: "https://ai-radar.shunniehub.com",
+  AI_RADAR_REPO: "https://github.com/Shunnie816/ai-radar",
 };
 export const TYPING_TEXT = [
   "Hi, I am Nekonoko",

--- a/src/components/pages/Home/presentations/Works/index.tsx
+++ b/src/components/pages/Home/presentations/Works/index.tsx
@@ -23,6 +23,20 @@ export const Works = () => {
           zennUrl={URL.STUDY_TRACKER_ZENN}
           workUrl={URL.STUDY_TRACKER}
         />
+        <WorkCard
+          title="AI Radar"
+          description="A personal system that automatically collects and summarizes AI news daily from multiple RSS sources using Claude API to keep up with the latest AI trends."
+          skills={[
+            "TypeScript",
+            "Next.js",
+            "React",
+            "Firebase",
+            "Cloud Functions",
+            "Claude API",
+          ]}
+          repogitoryUrl={URL.AI_RADAR_REPO}
+          workUrl={URL.AI_RADAR}
+        />
       </CardsWrapper>
     </WorksWrapper>
   );

--- a/src/components/pages/Home/presentations/Works/styles.ts
+++ b/src/components/pages/Home/presentations/Works/styles.ts
@@ -18,9 +18,21 @@ const cardsWrapper = css`
     flex-flow: row wrap;
     justify-content: center;
 
-    .child {
-      margin: 0 var(--spacing-1);
+    /* 3+ cards: 3 columns */
+    > * {
       width: 31%;
+    }
+
+    /* exactly 1 card: centered */
+    > *:only-child {
+      max-width: 480px;
+      width: 100%;
+    }
+
+    /* exactly 2 cards: 2 columns */
+    > *:first-child:nth-last-child(2),
+    > *:first-child:nth-last-child(2) ~ * {
+      width: 48%;
     }
   }
 `;

--- a/src/components/parts/WorkCard/index.tsx
+++ b/src/components/parts/WorkCard/index.tsx
@@ -25,7 +25,7 @@ type Props = {
   description: string;
   skills: string[];
   repogitoryUrl: string;
-  zennUrl: string;
+  zennUrl?: string;
   workUrl: string;
 };
 
@@ -61,12 +61,14 @@ export const WorkCard = ({
               <Typography sx={titleSx}>View Application</Typography>
             </LinkContainer>
           </Link>
-          <Link href={zennUrl} target="_blank" rel="noreferrer noopener">
-            <LinkContainer>
-              <Icon icon="zenn" color="primary" />
-              <Typography sx={titleSx}>Details</Typography>
-            </LinkContainer>
-          </Link>
+          {zennUrl && (
+            <Link href={zennUrl} target="_blank" rel="noreferrer noopener">
+              <LinkContainer>
+                <Icon icon="zenn" color="primary" />
+                <Typography sx={titleSx}>Details</Typography>
+              </LinkContainer>
+            </Link>
+          )}
         </LinksWrapper>
         <div>
           {skills.map((skill) => (


### PR DESCRIPTION
## 概要

My Works セクションに新アプリ「AI Radar」の WorkCard を追加する。
合わせて `WorkCard` の `zennUrl` を optional 化し、Zenn 記事がない作品でも Details リンクを非表示にできるようにした。

## 対応 Issue

Closes #58

## 変更内容

- `WorkCard`: `zennUrl` を `string` → `string | undefined` (optional) に変更し、値がある場合のみ Zenn リンクを表示
- `constants.ts`: AI Radar の URL 定数を追加 (`AI_RADAR`, `AI_RADAR_REPO`)
- `Works/index.tsx`: AI Radar の WorkCard を追加

## 確認事項

- [x] 型エラーなし (`npx tsc --noEmit`)
- [x] lint: husky の lint-staged がコミット時に確認済み
- [ ] build: CI で確認