### PR TITLE
chore: add release-note skill

### DIFF
--- a/.claude/skills/release-note/SKILL.md
+++ b/.claude/skills/release-note/SKILL.md
@@ -1,0 +1,63 @@
+---
+description: リリースノートを作成して GitHub Release を公開する。main へのマージ完了後に使う。
+---
+
+# /release-note — リリースノート作成
+
+## 手順
+
+1. **最新リリースタグを確認**する:
+   ```bash
+   gh release list --limit 1
+   ```
+
+2. **前回リリース以降のコミット・PRを収集**する:
+   ```bash
+   git log <前回タグ>..origin/main --oneline
+   gh pr list --state merged --base main --limit 10 --json number,title,mergedAt
+   ```
+
+3. **次のバージョンを決定**する（Semantic Versioning）:
+   - `feat:` を含む → minor バージョンを上げる（例: v1.3.0 → v1.4.0）
+   - `fix:` / `refactor:` のみ → patch バージョンを上げる（例: v1.3.0 → v1.3.1）
+   - 破壊的変更がある場合 → major バージョンを上げる
+
+4. **リリースノートを以下のテンプレートで作成**し、GitHub Release を公開する:
+   ```bash
+   gh release create <タグ> \
+     --title "<タグ> - <リリースタイトル>" \
+     --notes "..." \
+     --target main
+   ```
+
+## リリースノートテンプレート
+
+```markdown
+## What's New
+
+### Features
+- （feat: コミットをもとに記述）
+
+### Bug Fixes
+- （fix: コミットをもとに記述）
+
+### Refactor
+- （refactor: コミットをもとに記述）
+
+### Chore
+- （chore: コミットをもとに記述）
+```
+
+- 変更がないセクションは省略する
+- 箇条書きはユーザー視点の説明にする（コミットメッセージの直訳ではなく意訳）
+- リリースタイトルは変更内容を端的に表す英語のフレーズ（例: "AI Radar Card & Layout Improvements"）
+
+## サブエージェント戦略
+
+- このスキルはシンプルな操作が中心のため、サブエージェントは基本不要
+
+## 注意
+
+- タグは `v<major>.<minor>.<patch>` 形式
+- `--target main` を必ず指定する
+- リリース公開は不可逆なので、内容を確認してから実行する


### PR DESCRIPTION
## 概要

リリースノート作成作業を `/release-note` スキルとして定型化する。
毎回手動で行っていた「バージョン決定 → リリースノート作成 → GitHub Release 公開」の手順をスキルファイルに記述する。

## 変更内容

- `.claude/skills/release-note/SKILL.md` を追加
  - 最新タグ確認・コミット収集・バージョン決定（Semantic Versioning）の手順
  - リリースノートテンプレート（Features / Bug Fixes / Refactor / Chore）
  - `gh release create` コマンドの定形

## 確認事項

- [x] 型エラーなし（対象外）
- [x] lint: 対象外（.md ファイル）
- [ ] build: CI で確認