### PR TITLE
chore: Claude Code スキルを現行フォーマットへ移行し重複ルールを削除する

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -12,12 +12,14 @@
       "Bash(git add*)",
       "Bash(git commit*)",
       "Bash(git push*)",
+      "Bash(git fetch*)",
+      "Bash(./scripts/issue-start.sh*)",
       "Bash(gh issue create*)",
-      "Bash(gh issue view*)",
-      "Bash(gh issue comment*)",
       "Bash(gh issue edit*)",
-      "Bash(gh pr create*)",
-      "Bash(gh pr view*)"
+      "Bash(gh issue view*)",
+      "Bash(gh pr view*)",
+      "Bash(gh pr list*)",
+      "Bash(gh release list*)"
     ],
     "deny": [
       "Bash(npm run lint)",

--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -1,40 +1,45 @@
 ---
+name: implement
 description: タスクリストをもとに実装を進め、各タスク完了後にコミットする。実装フェーズに入るとき、またはサブスコープ（component, hook, style, config）を指定して実装するときに使う。
+argument-hint: "[component|hook|style|config]"
+allowed-tools: Bash(gh issue view:*), Bash(git branch:*), Bash(git log:*), Bash(git status:*), Bash(npx tsc --noEmit)
 ---
 
 # /implement — 実装担当
 
+## 現在の状態
+
+```!
+echo "branch: $(git branch --show-current)"
+echo "--- commits (main..HEAD) ---"
+git log main..HEAD --oneline
+echo "--- working tree ---"
+git status --short
+N=$(git branch --show-current | sed -n 's/.*issue-\([0-9][0-9]*\).*/\1/p')
+if [ -n "$N" ]; then
+  echo "--- Issue #$N の最新タスクコメント ---"
+  gh issue view "$N" --json comments --jq '.comments[-1].body // "（タスクコメントなし）"'
+fi
+```
+
 ## 手順
 
-1. `.claude/issue-context.md` から Issue 番号・ブランチ名を読み取る。
-2. `gh issue view <番号>` でタスクチェックリストを確認する。
-3. 未完了タスクを上から順に実装する。
-4. 各タスク完了後に Conventional Commits 形式でコミットする:
-   - `feat:` 新機能
-   - `fix:` バグ修正
-   - `refactor:` リファクタリング
-   - `chore:` ツール・設定変更
-   - `docs:` ドキュメント
-5. 全タスク完了後にユーザーへ報告する。
+1. 上記のタスクチェックリストから、未完了のものを上から順に実装する。
+2. 各タスク完了後にコミットする。
+3. 全タスク完了後にユーザーへ報告する。
 
 ## コミット規約
 
-- 1コミット = 1責務
-- 無関係な変更を混ぜない
-- コミット前に型チェックを実行する（`npx tsc --noEmit`）
-- lint は husky の lint-staged がコミット時に自動で実行するため、手動実行は不要
+- Conventional Commits 形式（`feat:` / `fix:` / `refactor:` / `test:` / `chore:` / `docs:`）
+- 1コミット = 1責務。無関係な変更を混ぜない
+- コミット前に `npx tsc --noEmit` を実行する
+- lint は husky の lint-staged がコミット時に自動実行するため、手動実行は不要
 
-## サブエージェント戦略
+## サブスコープ
 
-- 実装前のコードベース調査 → `Explore` サブエージェント（`haiku`）に委任する
-- 通常の実装タスク → メインモデルで実行する
-- 複雑なアーキテクチャ判断が必要な場合 → `opus` サブエージェントに委任する
+`$ARGUMENTS` にスコープ名が指定された場合、その範囲に絞って実装する:
 
-## サブスキル
-
-`$ARGUMENTS` にサブスキル名を指定すると、そのスコープに絞って実装する:
-
-- `component` — UI コンポーネントの実装
-- `hook` — カスタム React フックの実装
-- `style` — スタイル定義の実装
-- `config` — 設定ファイルの変更
+- `component` — UI コンポーネント
+- `hook` — カスタム React フック
+- `style` — スタイル定義
+- `config` — 設定ファイル

--- a/.claude/skills/plan/SKILL.md
+++ b/.claude/skills/plan/SKILL.md
@@ -1,27 +1,37 @@
 ---
+name: plan
 description: Issue を解析して実装タスクをチェックリスト化し、Issue にコメント投稿する。Issue 起点の開発を始めるとき、タスク分解が必要なときに使う。
+argument-hint: "[issue-number]"
+allowed-tools: Bash(gh issue view:*), Bash(git branch:*), Bash(./scripts/issue-start.sh:*), mcp__github__add_issue_comment
 ---
 
 # /plan — Issue 計画担当
 
+## 対象 Issue と現在のブランチ
+
+```!
+echo "branch: $(git branch --show-current)"
+N="$ARGUMENTS"
+case "$N" in ''|*[!0-9]*) N=$(git branch --show-current | sed -n 's/.*issue-\([0-9][0-9]*\).*/\1/p') ;; esac
+if [ -n "$N" ]; then
+  gh issue view "$N" --json number,title,body,labels,state,url
+else
+  echo 'ERROR: Issue 番号を解決できませんでした'
+fi
+```
+
 ## 手順
 
-1. `$ARGUMENTS` に Issue 番号が渡された場合はそれを使う。なければ `.claude/issue-context.md` から Issue 番号を読み取る。
-2. `gh issue view <番号>` で Issue の本文・ラベルを取得する。
-3. Issue の内容を踏まえて実装タスクをチェックリスト形式で整理する。
-4. タスクをユーザーに提示し、追加・修正があれば反映する。
-5. 合意後、以下のコマンドで Issue にコメントとして投稿する:
-   ```bash
-   gh issue comment <番号> --body "## タスク\n- [ ] ..."
-   ```
-6. 現在のブランチが `main` であれば `./scripts/issue-start.sh <番号>` でブランチを作成する。すでに作業ブランチにいる場合はスキップする。
+1. 上記の Issue 本文とラベルから、実装タスクをチェックリスト形式に分解する。
+   Issue 番号が解決できていない場合は、先にユーザーへ番号を確認する。
+2. タスクをユーザーに提示し、追加・修正があれば反映する。
+3. 合意後、`mcp__github__add_issue_comment` で Issue にコメントする。
+   - `owner: Shunnie816` / `repo: portfolio-site` / `issue_number: <番号>`
+   - `body` には**生の改行をそのまま**含める（`\n` とエスケープしない）
+4. 現在のブランチが `main` であれば `./scripts/issue-start.sh <番号>` でブランチを作成する。
+   すでに作業ブランチにいる場合はスキップする。
 
-## サブエージェント戦略
-
-- コードベーススキャンが必要な場合 → `Explore` サブエージェント（`haiku`）に委任する
-- Issue 解析・タスク分解はメインモデルで行う
-
-## 出力フォーマット
+## コメント本文のフォーマット
 
 ```markdown
 ## タスク

--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -1,20 +1,31 @@
 ---
-description: lint・ビルド確認後、develop への PR をテンプレートに従って作成する。実装が完了してレビュー依頼を出すときに使う。
+name: pr
+description: 型チェック後、main への PR をテンプレートに従って作成する。実装が完了してレビュー依頼を出すときに使う。
+allowed-tools: Bash(git log:*), Bash(git branch:*), Bash(git push:*), Bash(npx tsc --noEmit), mcp__github__create_pull_request
 ---
 
 # /pr — PR 作成担当
 
+## 現在の状態
+
+```!
+echo "branch: $(git branch --show-current)"
+echo "--- commits (main..HEAD) ---"
+git log main..HEAD --oneline
+N=$(git branch --show-current | sed -n 's/.*issue-\([0-9][0-9]*\).*/\1/p')
+[ -n "$N" ] && echo "issue: #$N"
+```
+
 ## 手順
 
-1. `.claude/issue-context.md` から Issue 番号・ブランチ名を読み取る。
-2. `git log main..HEAD --oneline` で変更コミットを確認する。
-3. `npx tsc --noEmit` を実行して型エラーがないことを確認する。
-4. 以下のテンプレートで PR を作成する:
-   - lint は husky の lint-staged がコミット時に実行済み
-   - build の最終確認は CI に委ねる
-   ```bash
-   gh pr create --base main --head <ブランチ名> --title "<タイトル>" --body "..."
-   ```
+1. `npx tsc --noEmit` を実行して型エラーがないことを確認する。
+2. `git push -u origin <ブランチ名>` でブランチを push する。
+3. `mcp__github__create_pull_request` で PR を作成する。
+   - `owner: Shunnie816` / `repo: portfolio-site` / `base: main` / `head: <ブランチ名>`
+   - `body` には**生の改行をそのまま**含める（`\n` とエスケープしない）
+   - タイトルは Conventional Commits に準じる形式（`feat:`, `fix:`, `chore:` など）
+
+lint は husky の lint-staged がコミット時に実行済み。build の最終確認は CI に委ねる。
 
 ## PR テンプレート
 
@@ -38,13 +49,7 @@ Closes #<番号>
 - [ ] build: CI で確認
 ```
 
-## サブエージェント戦略
-
-- このスキルはシンプルな操作が中心のため、サブエージェントは基本不要
-- コミット履歴やコードの広範なスキャンが必要な場合のみ `haiku` で委任する
-
 ## 注意
 
-- PR のベースブランチは必ず `main`
-- タイトルは Conventional Commits に準じる形式（`feat:`, `fix:` など）
-- `Closes #番号` を本文に含めること
+- ベースブランチは必ず `main`
+- `Closes #<番号>` を本文に含めること

--- a/.claude/skills/release-note/SKILL.md
+++ b/.claude/skills/release-note/SKILL.md
@@ -1,34 +1,39 @@
 ---
+name: release-note
 description: リリースノートを作成して GitHub Release を公開する。main へのマージ完了後に使う。
+allowed-tools: Bash(gh release list:*), Bash(gh pr list:*), Bash(git log:*), Bash(git fetch:*), Bash(gh release create:*)
 ---
 
 # /release-note — リリースノート作成
 
+## 前回リリース以降の変更
+
+```!
+git fetch origin main --tags --quiet
+LATEST=$(gh release list --limit 1 --json tagName --jq '.[0].tagName // ""')
+echo "latest release: ${LATEST:-（リリースなし）}"
+echo "--- commits ---"
+if [ -n "$LATEST" ]; then
+  git log "$LATEST"..origin/main --oneline
+else
+  git log origin/main --oneline --max-count=30
+fi
+echo "--- merged PRs ---"
+gh pr list --state merged --base main --limit 10 --json number,title,mergedAt
+```
+
 ## 手順
 
-1. **最新リリースタグを確認**する:
+1. 上記のコミット・PR から次のバージョンを決定する（Semantic Versioning）:
+   - `feat:` を含む → minor を上げる（例: v1.3.0 → v1.4.0）
+   - `fix:` / `refactor:` のみ → patch を上げる（例: v1.3.0 → v1.3.1）
+   - 破壊的変更がある → major を上げる
+2. 下記テンプレートでリリースノートを作成し、**ユーザーに提示して確認を取る**。
+3. 承認後に GitHub Release を公開する:
    ```bash
-   gh release list --limit 1
+   gh release create <タグ> --title "<タグ> - <リリースタイトル>" --target main --notes-file -
    ```
-
-2. **前回リリース以降のコミット・PRを収集**する:
-   ```bash
-   git log <前回タグ>..origin/main --oneline
-   gh pr list --state merged --base main --limit 10 --json number,title,mergedAt
-   ```
-
-3. **次のバージョンを決定**する（Semantic Versioning）:
-   - `feat:` を含む → minor バージョンを上げる（例: v1.3.0 → v1.4.0）
-   - `fix:` / `refactor:` のみ → patch バージョンを上げる（例: v1.3.0 → v1.3.1）
-   - 破壊的変更がある場合 → major バージョンを上げる
-
-4. **リリースノートを以下のテンプレートで作成**し、GitHub Release を公開する:
-   ```bash
-   gh release create <タグ> \
-     --title "<タグ> - <リリースタイトル>" \
-     --notes "..." \
-     --target main
-   ```
+   本文はヒアドキュメントで渡す（`--notes "..."` は改行がリテラル化するため使わない）。
 
 ## リリースノートテンプレート
 
@@ -52,12 +57,8 @@ description: リリースノートを作成して GitHub Release を公開する
 - 箇条書きはユーザー視点の説明にする（コミットメッセージの直訳ではなく意訳）
 - リリースタイトルは変更内容を端的に表す英語のフレーズ（例: "AI Radar Card & Layout Improvements"）
 
-## サブエージェント戦略
-
-- このスキルはシンプルな操作が中心のため、サブエージェントは基本不要
-
 ## 注意
 
 - タグは `v<major>.<minor>.<patch>` 形式
 - `--target main` を必ず指定する
-- リリース公開は不可逆なので、内容を確認してから実行する
+- **リリース公開は不可逆**。手順2の確認を必ず経ること

--- a/.claude/skills/test/SKILL.md
+++ b/.claude/skills/test/SKILL.md
@@ -1,15 +1,26 @@
 ---
+name: test
 description: テスト観点を列挙してテストコードを作成する。ビジネスロジックやカスタムフックのテストが必要なとき、実装後の品質確認をするときに使う。
+argument-hint: "[file-path or function-name]"
+allowed-tools: Bash(git diff:*), Bash(npm run lint:style)
 ---
 
 # /test — テスト担当
 
+## 直近の変更
+
+```!
+git diff main...HEAD --stat
+```
+
 ## 手順
 
-1. `$ARGUMENTS` に対象ファイル・関数名が渡された場合はそれを対象にする。なければ直近の実装変更（`git diff develop`）から対象を特定する。
+1. `$ARGUMENTS` に対象ファイル・関数名が渡された場合はそれを対象にする。
+   なければ上記の差分から対象を特定する。
 2. テスト観点を列挙してユーザーに提示する（実装前に合意を取る）。
 3. テストコードを作成する。
-4. `npm run lint` を実行してエラーがないことを確認する。
+4. `npm run lint:style` でスタイル系の lint を確認する。
+   ESLint とビルドは Claude Code では実行しない（husky の lint-staged と CI が担当する）。
 
 ## テスト観点の列挙フォーマット
 
@@ -31,12 +42,8 @@ description: テスト観点を列挙してテストコードを作成する。�
 - Magic Number を使わない
 - モックは最小限にする
 
-## サブエージェント戦略
-
-- 既存テストパターンの調査 → `Explore` サブエージェント（`haiku`）に委任する
-- テストコード生成はメインモデルで実行する
-
 ## 注意
 
-- テストランナーが未設定の場合は Jest + React Testing Library の導入を先に提案する
-- UIの見た目はテストしない（ビジネスロジックとカスタムフックを優先する）
+- **テストランナーは未導入**（#69 で Vitest + React Testing Library を導入予定）。
+  導入前にこのスキルが呼ばれた場合は、先に #69 の対応を提案する。
+- UI の見た目はテストしない（ビジネスロジックとカスタムフックを優先する）

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,3 +1,8 @@
 {
-  "mcpServers": {}
+  "mcpServers": {
+    "github": {
+      "type": "http",
+      "url": "https://api.githubcopilot.com/mcp"
+    }
+  }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,39 +108,14 @@ npm run build-storybook # Storybook ビルド
 
 | コマンド | 役割 | 使い方 |
 | --- | --- | --- |
-| `/plan` | Issue を解析してタスクをチェックリスト化し、Issue にコメント投稿する | `/plan 43` or `/plan`（context から自動取得） |
+| `/plan` | Issue を解析してタスクをチェックリスト化し、Issue にコメント投稿する | `/plan 43` or `/plan`（ブランチ名から自動解決） |
 | `/implement` | タスクリストをもとに実装を進め、各タスク完了後にコミットする | `/implement` or `/implement hook` |
 | `/test` | テスト観点を列挙してテストコードを作成する | `/test src/hooks/useFoo.ts` |
-| `/pr` | lint・ビルド確認後、`main` への PR をテンプレートに従って作成する | `/pr` |
+| `/pr` | 型チェック後、`main` への PR をテンプレートに従って作成する | `/pr` |
+| `/release-note` | リリースノートを作成して GitHub Release を公開する | `/release-note` |
 
-### 推奨ワークフロー
-
-```
-./scripts/issue-start.sh <番号>  →  /plan  →  /implement  →  /test  →  /pr
-```
-
-## サブエージェント戦略
-
-`Agent` ツールでサブタスクを委任するとき、以下の基準でモデルを選ぶ。
-
-| タスク種別 | モデル | 具体例 |
-| --- | --- | --- |
-| ファイル探索・コード調査 | `haiku` | Explore agent、glob、grep |
-| 通常の実装・テスト・PR 作成 | `sonnet` | 機能実装、テストコード生成 |
-| 複雑な設計・アーキテクチャ判断 | `opus` | 設計方針の検討、大規模リファクタ |
-
-各スキルにも同様のガイドが記載されており、スキル呼び出し時はスキル側の指示が優先される。
-
-## トークン節約ルール
-
-### 高コスト操作を避ける
-
-| 操作 | ガイドライン |
-| --- | --- |
-| `Read`（大きなファイル） | `offset` と `limit` で必要な行範囲に絞る |
-| コードベース全体の探索 | `Grep`・`Glob` で絞り込んでから `Read` する |
-| 広範な調査タスク | `Explore` サブエージェントに委任する（メインコンテキストを汚さない） |
-| 長い会話の継続 | `/compact` でコンテキストを圧縮する |
+各スキルは Issue・コミット履歴を `` ```! `` のインライン展開で先読みする。Issue 番号は
+引数がなければブランチ名（`{prefix}/issue-{番号}-{slug}`）から解決される。
 
 ## チェック実行の役割分担
 
@@ -158,5 +133,5 @@ lint・build の二重実行を防ぐため、チェックの実行主体を明�
 
 ## 注意事項
 
-- テストランナーは現時点で未設定。テストを追加する場合は Jest + React Testing Library の導入を検討すること
+- テストランナーは現時点で未設定。Vitest + React Testing Library の導入を #69 で予定している
 - Storybook は Vite ベース (`@storybook/nextjs-vite`) で動作する


### PR DESCRIPTION
## 概要

数か月前に構築されたハーネスの点検結果を反映。自前の散文ルールのうち、**壊れていたもの・事実として古くなったもの・重複していたもの**を Claude Code の現行機能（スキル frontmatter、`` ```! `` インライン展開、GitHub MCP）に置き換えた。

## 対応 Issue

Closes #66

## 変更内容

### 修正した不具合

| # | 内容 |
| --- | --- |
| A1 | `test/SKILL.md` が `npm run lint` を実行させていたが settings.json の deny リストに入っており**実行不能**だった → `npm run lint:style` に修正 |
| A2 | `test/SKILL.md` が存在しない `develop` ブランチを参照していた → `git diff main...HEAD` に修正 |
| A3 | `pr/SKILL.md` の frontmatter description が「develop への PR」のままだった。description は自律起動の判断材料なので、一番効く場所だけ古い状態だった → `main` ベースに修正 |
| A4 | `plan/SKILL.md` の `gh issue comment --body "## タスク\n- [ ] ..."` は bash ダブルクォート内なので `\n` がリテラル文字列として投稿される。**チェックリストが改行されない**バグ → GitHub MCP に移行して解消 |
| B1 | 全5スキル + CLAUDE.md の「Explore サブエージェント（haiku）に委任する」は、Explore が v2.1.198 以降メイン会話のモデルを継承するため指定として成立しない → 削除 |
| B2 | CLAUDE.md のスキル表に `/release-note` が無かった → 追加 |

### スキル（`.claude/skills/*/SKILL.md`）

- 全スキルに frontmatter（`name` / `argument-hint` / `allowed-tools`）を追加
- Issue・PR・コミット履歴の取得を `` ```! `` インライン展開に置き換え、Claude 側のツール往復を削減
- Issue 番号は引数がなければ**ブランチ名から自動解決**（`{prefix}/issue-{番号}-{slug}`）
- 書き込み（Issue コメント・PR 作成）を GitHub MCP に移行し、改行のエスケープ問題を根本から回避
- `release-note` の `gh release create` は不可逆なため Bash のまま残し、`--notes "..."` → `--notes-file -` に変更

### 設定

- `.mcp.json` に GitHub MCP をプロジェクトスコープで宣言（`enableAllProjectMcpServers: true` に対し中身が空の死に設定だった）
- `settings.json`: 書き込み系 gh 権限を allow から削除しスキル側 `allowed-tools` に委譲。読み取り系 gh とワークフロー起点を追加。**deny は変更なし**
- CLAUDE.md から「サブエージェント戦略」表と「トークン節約ルール」表、重複していた「推奨ワークフロー」を削除

## 確認事項

- [x] 型エラーなし (`npx tsc --noEmit`)
- [x] `.mcp.json` / `settings.json` の JSON 妥当性を確認
- [x] 各スキルの `` ```! `` ブロックを実際に実行し、引数あり・なし（ブランチ名解決）の両経路で正しく動作することを確認
- [x] lint: husky の lint-staged がコミット時に確認済み
- [ ] build: CI で確認

## 後続

- #67 Issue コンテキストの受け渡しを SessionStart hook に置き換える
- #68 CI ワークフローの重複実行を解消する
- #69 Vitest + React Testing Library を導入する

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G4HjCeskGMMGSqUVuS3q7w