### PR TITLE
chore: Issue コンテキストの受け渡しを SessionStart hook に置き換える

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -30,15 +30,14 @@
     ]
   },
   "hooks": {
-    "PostToolUse": [
+    "SessionStart": [
       {
-        "matcher": ".*",
+        "matcher": "startup|resume|clear",
         "hooks": [
           {
             "type": "command",
-            "command": "mkdir -p \"$CLAUDE_PROJECT_DIR/.claude/logs\" && jq -r '\"\\(now | todate) \\(.tool_name)\"' >> \"$CLAUDE_PROJECT_DIR/.claude/logs/tool-usage.log\"",
-            "timeout": 5,
-            "async": true
+            "command": "node \"$CLAUDE_PROJECT_DIR/scripts/session-context.mjs\"",
+            "timeout": 15
           }
         ]
       }

--- a/.gitignore
+++ b/.gitignore
@@ -42,8 +42,6 @@ PR_DESCRIPTION.md
 
 # Claude Code (local settings)
 .claude/settings.local.json
-.claude/issue-context.md
-.claude/logs/
 
 # Serena MCP (local tool config)
 .serena/

--- a/package.json
+++ b/package.json
@@ -18,6 +18,9 @@
       "eslint --fix",
       "stylelint --fix"
     ],
+    "*.{js,mjs,cjs}": [
+      "eslint --fix"
+    ],
     "*.{css,scss}": [
       "stylelint --fix"
     ]

--- a/scripts/issue-start.sh
+++ b/scripts/issue-start.sh
@@ -72,38 +72,10 @@ else
   git checkout -b "$BRANCH_NAME" "origin/${BASE_BRANCH}"
 fi
 
-# --- Claude Code 向けコンテキストファイルを生成 ---
-CONTEXT_FILE=".claude/issue-context.md"
-cat > "$CONTEXT_FILE" <<CONTEXT
-# Issue #${ISSUE_NUMBER}: ${TITLE}
-
-## 対応ブランチ
-\`${BRANCH_NAME}\`
-
-## Issue 本文
-${BODY}
-
-## ラベル
-${LABELS}
-
-## Claude Code への作業指示
-
-以下のワークフローで作業してください:
-
-1. **タスク分解**: Issue の内容を具体的な実装タスクに分解し、ユーザーと確認する
-2. **Issue 更新**: 合意したタスクをチェックリスト形式で Issue #${ISSUE_NUMBER} にコメントする
-   \`\`\`bash
-   gh issue comment ${ISSUE_NUMBER} --body "## タスク\n- [ ] ..."
-   \`\`\`
-3. **実装**: タスクをひとつずつ実装し、各タスク完了後にコミットする
-4. **PR 作成**: 全タスク完了後、以下の形式で PR を作成する
-   - ベースブランチ: \`main\`
-   - 本文に \`Closes #${ISSUE_NUMBER}\` を含める
-CONTEXT
-
 echo ""
 echo "=== 準備完了 ==="
-echo "コンテキストファイル: $CONTEXT_FILE"
+echo "Issue 本文とタスクは SessionStart hook (scripts/session-context.mjs) が"
+echo "ブランチ名から解決して Claude Code に渡します。"
 echo ""
 echo "--- Issue 本文 ---"
 echo "$BODY"

--- a/scripts/session-context.mjs
+++ b/scripts/session-context.mjs
@@ -1,0 +1,81 @@
+#!/usr/bin/env node
+/**
+ * SessionStart hook — 作業ブランチ名から Issue 番号を導出し、
+ * Issue のタイトル・ラベル・本文を Claude のコンテキストに注入する。
+ *
+ * ブランチ名の形式: {prefix}/issue-{番号}-{slug}
+ *
+ * 状態ファイル（旧 .claude/issue-context.md）を持たないのは、
+ * ブランチ名が既に Issue 番号を持っており、Claude が読み忘れる余地をなくすため。
+ *
+ * 出力なし（exit 0）となるケース:
+ *   - main ブランチ、または Issue 番号を含まないブランチ
+ *   - git / gh が使えない、gh 未認証、Issue 取得失敗
+ * いずれもセッション開始を妨げてはならないため、エラーを無視して静かに終了する。
+ */
+import { execFileSync } from "node:child_process";
+
+const BRANCH_ISSUE_PATTERN = /issue-(\d+)/;
+
+/** コマンドを実行し、失敗したら null を返す（セッション開始を妨げないため）。 */
+function run(command, args) {
+  try {
+    return execFileSync(command, args, {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+  } catch {
+    return null;
+  }
+}
+
+function resolveIssueNumber() {
+  const branch = run("git", ["branch", "--show-current"]);
+  return branch?.match(BRANCH_ISSUE_PATTERN)?.[1] ?? null;
+}
+
+function fetchIssue(issueNumber) {
+  const raw = run("gh", [
+    "issue",
+    "view",
+    issueNumber,
+    "--json",
+    "number,title,state,labels,body,url",
+  ]);
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return null;
+  }
+}
+
+function buildContext(issue) {
+  const labels = issue.labels.map((label) => label.name).join(", ") || "なし";
+  return [
+    `## 作業中の Issue #${issue.number}: ${issue.title}`,
+    "",
+    `- 状態: ${issue.state}`,
+    `- ラベル: ${labels}`,
+    `- URL: ${issue.url}`,
+    "",
+    "### 本文",
+    "",
+    issue.body?.trim() || "（本文なし）",
+  ].join("\n");
+}
+
+const issueNumber = resolveIssueNumber();
+if (!issueNumber) process.exit(0);
+
+const issue = fetchIssue(issueNumber);
+if (!issue) process.exit(0);
+
+process.stdout.write(
+  JSON.stringify({
+    hookSpecificOutput: {
+      hookEventName: "SessionStart",
+      additionalContext: buildContext(issue),
+    },
+  }),
+);

--- a/scripts/session-context.mjs
+++ b/scripts/session-context.mjs
@@ -77,5 +77,5 @@ process.stdout.write(
       hookEventName: "SessionStart",
       additionalContext: buildContext(issue),
     },
-  }),
+  })
 );


### PR DESCRIPTION
## 概要

`.claude/issue-context.md` という状態ファイルを廃止し、SessionStart hook で **ブランチ名から Issue 番号を導出**してコンテキストに注入する方式に置き換えた。

これまでは `scripts/issue-start.sh` がファイルを書き出し、各スキルが「そのファイルを読む」ことを散文で指示していた。つまり **Claude が読み忘れれば効かない**状態で、ハーネスとして保証されていなかった。ブランチ名（`{prefix}/issue-{番号}-{slug}`）が既に Issue 番号を持っているため、状態ファイル自体が不要。

## 対応 Issue

Closes #67

## 変更内容

### 追加: `scripts/session-context.mjs`

- `git branch --show-current` から `/issue-(\d+)/` で Issue 番号を抽出
- `gh issue view` でタイトル・状態・ラベル・本文を取得し、`hookSpecificOutput.additionalContext` として stdout に出力
- **Node 実装**（旧 hook の `jq` / `mkdir -p` 依存を排除、Windows でも動く）
- `main` / Issue 番号なしのブランチ / `gh` 失敗時は**何も出力せず exit 0**。セッション開始を絶対に妨げない

### `.claude/settings.json`

- PostToolUse のツール使用ログ hook を**削除**
  - matcher `.*` で全ツール呼び出しに発火していたが、出力先 `.claude/logs/` は gitignore 済みで読む主体がいなかった（193行が蓄積、ローテーションなし）
- SessionStart hook を追加（matcher: `startup|resume|clear`）

### その他

- `scripts/issue-start.sh` からコンテキストファイル生成を削除し、責務を**ブランチ作成のみ**に
- `.claude/issue-context.md` と `.claude/logs/` を削除、`.gitignore` からも除去

### 解消された重複

同じワークフロー記述が4箇所にあったのを1箇所に集約:

| 箇所 | 対応 |
| --- | --- |
| `issue-context.md` の「Claude Code への作業指示」 | 削除（本 PR） |
| CLAUDE.md の「推奨ワークフロー」 | 削除済み（#66） |
| `plan` / `implement` / `pr` の各 SKILL.md | 各スキルの責務のみ残す（#66） |

## 確認事項

- [x] 型エラーなし (`npx tsc --noEmit`)
- [x] `bash -n scripts/issue-start.sh` 構文チェック通過
- [x] 作業ブランチで hook コマンドを実行し、`hookEventName: SessionStart` と本文を含む正しい JSON が出ることを確認
- [x] Issue 番号を含まないブランチで**出力なし・exit 0** になることを確認
- [x] lint: husky の lint-staged がコミット時に確認済み
- [ ] build: CI で確認
- [ ] マージ後、作業ブランチで新規セッションを開始して Issue 情報が実際に注入されることを確認

## 後続

- #68 CI ワークフローの重複実行を解消する

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G4HjCeskGMMGSqUVuS3q7w