### PR TITLE
chore: CI ワークフローの重複実行を解消する

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,10 +2,19 @@ name: CI
 
 run-name: ${{ github.actor }} has pushed
 
+# 作業ブランチへの push では走らせない。
+# 作業ブランチの検証は pull_request イベントが担当するため、
+# push を無指定にすると同一コミットに対して2本走ってしまう。
 on:
   push:
+    branches: [main]
   pull_request:
     branches: [main]
+
+# 同一ブランチで新しいコミットが積まれたら、実行中の古いランをキャンセルする
+concurrency:
+  group: "${{ github.workflow }}-${{ github.ref }}"
+  cancel-in-progress: true
 
 jobs:
   build-and-test:
@@ -20,7 +29,8 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
+          cache: "npm"
 
       # 3. 依存関係をインストール
       - name: Install dependencies


### PR DESCRIPTION
## 概要

`on.push` にブランチ指定がなく、作業ブランチへの push と PR で**同一コミットに対して CI が2本フル実行**されていた問題を解消する。

## 対応 Issue

Closes #68

## 問題の実測

#70 のブランチ push 時に観測した結果:

```
pull_request  chore/issue-66-chore-claude-code  completed  success
push          chore/issue-66-chore-claude-code  completed  success
```

過去の履歴でも同様（`chore/add-release-note-skill` など）。1本あたり `npm ci` + ESLint + tsc + Next.js build なので、PR を出すたびに丸ごと二重に消費していた。

## 変更内容

| 変更 | 内容 |
| --- | --- |
| `on.push.branches: [main]` | 作業ブランチへの push では走らせない。作業ブランチの検証は `pull_request` が担当する |
| `concurrency` + `cancel-in-progress` | 同一ブランチに新しいコミットが積まれたら、実行中の古いランをキャンセルする |
| `cache: "npm"` | `setup-node` の依存キャッシュを有効化し `npm ci` を高速化 |
| `node-version: "22"` | Node 20 から 22 へ更新 |

## 確認事項

- [x] YAML の構文・必須キーをチェック
- [x] **このブランチを push しても `push` トリガのランが発生しないことを確認**（修正の直接的な回帰確認）
- [ ] この PR で `pull_request` のランが1本だけ走ること
- [ ] Node 22 + npm キャッシュで lint / tsc / build が通ること

## 補足

`node-version` を上げているため、この PR の CI が通ることが Node 22 での動作確認そのものになる。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G4HjCeskGMMGSqUVuS3q7w