### PR TITLE
docs: コミットメッセージ規約を CLAUDE.md に明記する

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,7 +74,29 @@ npm run test:watch      # Vitest ウォッチモード
 - **import の順序**: ESLint `import/order` ルールに従う（builtin → external → internal → parent → sibling）
 - **スタイル定義**: コンポーネントと同ディレクトリの `styles.ts` に Emotion `styled` で定義する
 - **型安全**: `any` を使用しない。型が不明な場合は `unknown` を使い、適切に narrowing する
-- **コミット**: Conventional Commits 形式 (`feat:`, `fix:`, `refactor:`, `test:`, `chore:`)
+- **コミット**: Conventional Commits 形式。詳細は下記「コミットメッセージ規約」を参照
+
+## コミットメッセージ規約
+
+commitlint（`commitlint.config.mjs`）が commit-msg hook で検証する。違反するとコミットできない。
+
+### type
+
+`feat` / `fix` / `refactor` / `test` / `chore` / `docs` / `style` / `ci` の8種のみ許可（`type-enum`）。
+
+### 件名を英大文字で始めない
+
+`@commitlint/config-conventional` の `subject-case` が sentence-case / start-case / pascal-case / upper-case を禁止しているため、
+**日本語の件名でも先頭が英大文字だと弾かれる**。
+
+```
+✖ chore: CI にテストステップを追加する
+✖ chore: Vitest + React Testing Library を導入する
+✅ chore: ワークフローにテストステップを追加する
+✅ chore: テストランナーとして Vitest を導入する
+```
+
+先頭に置きたい英単語がある場合は、語順を変えて日本語から書き始める。
 
 ## Git ワークフロー
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,13 +115,13 @@ commitlint（`commitlint.config.mjs`）が commit-msg hook で検証する。違
 
 ### ブランチ命名規則
 
-| ラベル             | プレフィックス |
-| ------------------ | -------------- |
-| bug / fix          | `fix/`         |
-| chore / setup / ci | `chore/`       |
-| docs               | `docs/`        |
-| refactor           | `refactor/`    |
-| その他             | `feature/`     |
+| ラベル               | プレフィックス |
+| -------------------- | -------------- |
+| bug / fix            | `fix/`         |
+| chore / setup / ci   | `chore/`       |
+| docs / documentation | `docs/`        |
+| refactor             | `refactor/`    |
+| その他               | `feature/`     |
 
 形式: `{prefix}/issue-{番号}-{タイトルのslug}`
 

--- a/scripts/issue-start.sh
+++ b/scripts/issue-start.sh
@@ -43,7 +43,7 @@ if echo "$LABELS" | grep -qi "bug\|fix"; then
   PREFIX="fix"
 elif echo "$LABELS" | grep -qi "chore\|setup\|ci"; then
   PREFIX="chore"
-elif echo "$LABELS" | grep -qi "docs"; then
+elif echo "$LABELS" | grep -qi "docs\|documentation"; then
   PREFIX="docs"
 elif echo "$LABELS" | grep -qi "refactor"; then
   PREFIX="refactor"


### PR DESCRIPTION
## 概要

#69 の作業中に commitlint の `subject-case` へ 2 回引っかかったため、コミットメッセージ規約を CLAUDE.md に明記した。

日本語の件名でも先頭が英大文字（`CI`、`Vitest` など）だと弾かれるが、CLAUDE.md には「Conventional Commits 形式」としか書かれておらず、規約を読んだだけでは踏むようになっていた。

あわせて、本 Issue の作業中に判明した `scripts/issue-start.sh` のラベル判定バグも修正している。

## 対応 Issue

Closes #74

## 変更内容

### 1. コミットメッセージ規約の明記（`docs:`）

- 「コーディング規約」から独立させて「コミットメッセージ規約」セクションを新設
- 件名を英大文字で始められない旨を NG / OK 例つきで追記
- 許可される type を `commitlint.config.mjs` の `type-enum` の実態（8種）に合わせて修正
  - 修正前: `feat` / `fix` / `refactor` / `test` / `chore` の5種のみ記載
  - 修正後: `docs` / `style` / `ci` を追加した8種

### 2. `issue-start.sh` のラベル判定バグ修正（`chore:`）

ラベル → ブランチプレフィックスの判定が `docs` しか見ておらず、このリポジトリの実ラベル名 `documentation` にマッチしていなかった。結果、docs 系 Issue でも `feature/` プレフィックスになっていた（#74 で実際に発生）。

```diff
-elif echo "$LABELS" | grep -qi "docs"; then
+elif echo "$LABELS" | grep -qi "docs\|documentation"; then
```

CLAUDE.md のブランチ命名規則の表も実ラベル名に合わせて更新した。

## 方針

`subject-case` を無効化する選択肢もあったが、既存のコミット履歴が日本語始まりで統一されているため、**ルールは変えずドキュメント側で明示する**方針を採った（Issue の検討事項どおり）。

## 動作確認

ラベル → プレフィックスの解決を修正後のロジックで確認済み。

| ラベル | プレフィックス |
| --- | --- |
| `documentation` | `docs` |
| `chore` | `chore` |
| `bug` | `fix` |
| `refactor` | `refactor` |
| `enhancement` | `feature` |

## 確認事項

- [x] 型エラーなし (`npx tsc --noEmit`)
- [x] lint: husky の lint-staged がコミット時に確認済み
- [ ] build: CI で確認
