### PR TITLE
fix: 未使用のテキスト色 CSS 変数を削除する

### DIFF
--- a/src/assets/styles/variable.ts
+++ b/src/assets/styles/variable.ts
@@ -44,8 +44,6 @@ export const variables = css`
 
     /* text color */
     --text-default: var(--color-dark-navy);
-    --text-normal: rgb(0 0 0 / 87%);
-    --text-dark: var(--color-color-gray);
 
     /* background-color */
     --bg-color-default: var(--color-gray);


### PR DESCRIPTION
## 概要

`--text-dark` が存在しない CSS 変数 `var(--color-color-gray)` を参照していた（`--color-gray` のタイポ）。

調査したところ `--text-dark` と `--text-normal` は**どちらも定義のみで、リポジトリ内から一度も参照されていなかった**。
タイポを直しても挙動が変わらないため、変数ごと削除する。

## 対応 Issue

Closes #81

## 変更内容

```diff
  /* text color */
  --text-default: var(--color-dark-navy);
- --text-normal: rgb(0 0 0 / 87%);
- --text-dark: var(--color-color-gray);
```

実際に使用されている `--text-default`（`global.ts` から参照）は残している。

## 調査結果

| 変数 | 参照箇所 | 対応 |
| --- | --- | --- |
| `--text-default` | `global.ts:12`, `global.ts:17` | 維持 |
| `--text-normal` | なし | 削除 |
| `--text-dark` | なし（かつ参照先が未定義） | 削除 |

`variable.ts` 内に残る `var()` 参照はすべて定義済みの変数を指している状態になった。

## スコープ外にした点

調査の過程で、他にも定義のみで未使用の変数が **13 個**あることがわかった。

- `--fontSizeXXS` 〜 `--fontSizeXXL`（7個）
- `--spacing-5` / `--spacing-8` / `--spacing-16`
- `--color-navy` / `--color-light-navy` / `--color-light-blue`

これらは「削除するか」ではなく「**そもそもどのトークンを持つべきか**」という設計判断になるため、
本 PR では触らず #80（CSS 変数と MUI テーマの二重管理を整理）で扱う。

## 確認事項

- [x] 型エラーなし (`npx tsc --noEmit`)
- [x] テスト: 13 passed (`npm test`)
- [x] Stylelint: エラーなし (`npm run lint:style`)
- [x] lint: husky の lint-staged がコミット時に確認済み
- [ ] build: CI で確認
