### PR TITLE
refactor: 色の定義を colors.ts に一本化する

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,8 +76,46 @@ npm run test:watch      # Vitest ウォッチモード
 
 - **import の順序**: ESLint `import/order` ルールに従う（builtin → external → internal → parent → sibling）
 - **スタイル定義**: コンポーネントと同ディレクトリの `styles.ts` に Emotion `styled` で定義する
+- **デザイントークン**: 下記「デザイントークンの一次情報」を参照する
 - **型安全**: `any` を使用しない。型が不明な場合は `unknown` を使い、適切に narrowing する
 - **コミット**: Conventional Commits 形式。詳細は下記「コミットメッセージ規約」を参照
+
+## デザイントークンの一次情報
+
+トークンの種類ごとに定義元を1つに固定している。**同じ値を2箇所に書かない。**
+
+| トークン | 一次情報 | 参照方法 |
+| --- | --- | --- |
+| 色 | `src/assets/styles/colors.ts` の `COLOR` | MUI テーマ経由（`sx={{ color: "text.primary" }}`）または CSS 変数経由（`var(--bg-color-dark)`） |
+| スペーシング | `src/assets/styles/variable.ts` | `var(--spacing-4)` |
+| ブレークポイント / ヘッダー高 | `src/assets/styles/variable.ts` | `${breakpoint}` / `${headerHeight}` を import して補間 |
+| フォントサイズ | `src/components/themes/index.ts` の `typography` | MUI の `variant`（`<Typography variant="h4">`） |
+
+### 色の流れ
+
+```
+colors.ts (COLOR)
+├── components/themes/index.ts … MUI パレット（sx / variant から参照）
+└── assets/styles/variable.ts  … CSS 変数（Emotion styled から参照）
+```
+
+`colors.ts` が唯一の hex 定義元。MUI テーマも CSS 変数もここを import して組み立てるため、
+**色を変えるときは `colors.ts` だけを編集すれば両系統に反映される**。
+
+以前は `themes/index.ts` と `variable.ts` の両方に hex を書き、
+「ここを変更したら variable.ts も変更する」というコメントで同期を担保していたが、実際に値が乖離していた（#80）。
+
+### ライト / ダークの切り替え
+
+`ThemeContext` が `<html>` の `data-color-scheme` 属性を切り替える。
+CSS 変数はこの属性セレクタで上書きし、MUI 側は `Layout` が `darkTheme` / `lightTheme` を出し分ける。
+
+- **常にダーク背景のセクション**（Hero / Footer）は `<ThemeProvider theme={darkTheme}>` で囲む
+- `--text-default` はモードによらず darkNavy 固定。ダーク背景内のテキストは `sx` で明示的に上書きする
+
+MUI の `cssVariables` + `colorSchemes` へ移行すればこの二系統を1つにできるが、
+`colorSchemes.dark` は `palette.mode: "dark"` を強制し、`divider` が `rgba(0,0,0,.12)` → `rgba(255,255,255,.12)` に変わる。
+常に白背景の Experiences で Stepper の区切り線が見えなくなるため見送っている（#80 に詳細）。
 
 ## コミットメッセージ規約
 

--- a/src/assets/styles/colors.ts
+++ b/src/assets/styles/colors.ts
@@ -1,0 +1,20 @@
+/**
+ * ブランドカラーの一次情報。
+ *
+ * ここが色の唯一の定義元であり、以下の2系統がどちらもこの定数を参照する。
+ * - MUI テーマのパレット（`components/themes/index.ts`）
+ * - CSS カスタムプロパティ（`assets/styles/variable.ts`）
+ *
+ * 色を変更するときはこのファイルだけを編集する。
+ */
+export const COLOR = {
+  darkNavy: "#201e43",
+  navy: "#134b70",
+  lightNavy: "#508c9b",
+  gray: "#eeeeee",
+  mediumGray: "#a0a0a0",
+  lightGray: "#fafafa",
+  lightBlue: "#eef7ff",
+  fog: "#64748b",
+  white: "#ffffff",
+} as const;

--- a/src/assets/styles/variable.ts
+++ b/src/assets/styles/variable.ts
@@ -1,4 +1,5 @@
 import { css } from "@emotion/react";
+import { COLOR } from "./colors";
 
 /* breakpoint */
 export const breakpoint = "768px";
@@ -21,24 +22,18 @@ export const variables = css`
     --spacing-18: 72px;
     --spacing-24: 96px;
 
-    /* color */
-    --color-dark-navy: #201e43;
-    --color-gray: #eee;
-    --color-white: #fff;
-
     /* text color */
-    --text-default: var(--color-dark-navy);
+    --text-default: ${COLOR.darkNavy};
 
     /* background-color */
-    --bg-color-default: var(--color-gray);
-    --bg-color-dark: var(--color-dark-navy);
-    --bg-color-light: var(--color-white);
+    --bg-color-default: ${COLOR.gray};
+    --bg-color-dark: ${COLOR.darkNavy};
+    --bg-color-light: ${COLOR.white};
   }
 
   /* dark mode overrides */
   [data-color-scheme="dark"] {
-    --bg-color-default: var(--color-dark-navy);
-    --bg-color-light: var(--color-white);
+    --bg-color-default: ${COLOR.darkNavy};
 
     /* --text-default はオーバーライドしない。常に darkNavy のままにする。
        ダーク背景セクション内のテキストは MUI sx で明示的に上書きする */

--- a/src/components/parts/Footer/styles.ts
+++ b/src/components/parts/Footer/styles.ts
@@ -1,10 +1,11 @@
 import { css } from "@emotion/react";
 import emotionStyled from "@emotion/styled";
+import { COLOR } from "@/assets/styles/colors";
 import { breakpoint } from "@/assets/styles/variable";
 
 const wrapper = css`
   background-color: var(--bg-color-dark);
-  border-top: 1px solid #64748b; /* text.disabled */
+  border-top: 1px solid ${COLOR.fog}; /* text.disabled と同色 */
   padding: var(--spacing-12) var(--spacing-4) var(--spacing-10);
 `;
 

--- a/src/components/themes/index.ts
+++ b/src/components/themes/index.ts
@@ -1,21 +1,11 @@
 import { createTheme } from "@mui/material";
 import { Mulish } from "next/font/google";
+import { COLOR as COLOR_PALETTE } from "@/assets/styles/colors";
 
 const mulish = Mulish({
   subsets: ["latin"],
   display: "swap",
 });
-
-// ここを変更したらvariable.tsも変更する
-const COLOR_PALETTE = {
-  darkNavy: "#201e43",
-  navy: "#134b70",
-  lightNavy: "#508c9b",
-  gray: "#eeeeee",
-  lightGray: "#fafafa",
-  lightBlue: "#eef7ff",
-  fog: "#64748b",
-};
 
 const typography = {
   fontFamily: mulish.style.fontFamily,
@@ -41,7 +31,7 @@ export const darkTheme = createTheme({
     secondary: {
       main: COLOR_PALETTE.gray,
       light: COLOR_PALETTE.lightGray,
-      dark: "#a0a0a0",
+      dark: COLOR_PALETTE.mediumGray,
     },
     text: {
       primary: COLOR_PALETTE.gray,
@@ -65,7 +55,7 @@ export const lightTheme = createTheme({
     secondary: {
       main: COLOR_PALETTE.darkNavy,
       light: COLOR_PALETTE.lightBlue, // lightGray はページ背景と同色になるため lightBlue に変更
-      dark: "#a0a0a0",
+      dark: COLOR_PALETTE.mediumGray,
     },
     text: {
       primary: COLOR_PALETTE.darkNavy,
@@ -74,7 +64,7 @@ export const lightTheme = createTheme({
     },
     background: {
       default: COLOR_PALETTE.lightGray,
-      paper: "#ffffff",
+      paper: COLOR_PALETTE.white,
     },
   },
   typography,


### PR DESCRIPTION
## 概要

#80 の**第2段階**（完了編）。色の一次情報を1箇所に集約し、二重管理を解消した。

## 対応 Issue

Closes #80

## 問題

`themes/index.ts` と `variable.ts` の両方に同じ hex を書き、コメントで同期を担保していた。

```ts
// ここを変更したらvariable.tsも変更する
const COLOR_PALETTE = { ... };
```

そして**実際に乖離していた**。

| トークン | `variable.ts` | `themes/index.ts` |
| --- | --- | --- |
| lightBlue | `#cde8e5` | `#eef7ff` |

乖離していたトークンが未使用だったため表示上の実害は出ていなかったが、色を1つ変えるたびに2ファイルを触る必要がある構造だった。

## 変更内容

`src/assets/styles/colors.ts` を新設し、**hex の唯一の定義元**とした。

```
colors.ts (COLOR)
├── components/themes/index.ts … MUI パレット（sx / variant から参照）
└── assets/styles/variable.ts  … CSS 変数（Emotion styled から参照）
```

- `themes/index.ts` の `COLOR_PALETTE` を廃止し `colors.ts` を参照
- `variable.ts` の hex を `COLOR` の補間に置き換え
- Footer の `border-top` に直書きされていた `#64748b` を `COLOR.fog` に
- CLAUDE.md に「デザイントークンの一次情報」セクションを追記

ブランドカラーの hex リテラルは `colors.ts` の外に**1つも残っていない**（404 ページは独立した配色のため対象外）。

### トークンごとの一次情報

| トークン | 定義元 |
| --- | --- |
| 色 | `assets/styles/colors.ts` |
| スペーシング | `assets/styles/variable.ts` |
| ブレークポイント / ヘッダー高 | `assets/styles/variable.ts` |
| フォントサイズ | `themes/index.ts` の `typography` |

## `cssVariables` + `colorSchemes` を見送った理由

当初は `createTheme({ cssVariables: true, colorSchemes: {...} })` で MUI theme に完全一本化する想定だったが、**実測して回帰が判明したため見送った**。

`colorSchemes.dark` は `palette.mode: "dark"` を強制する。

```
light.mode = light
dark.mode  = dark
divider(light) = rgba(0, 0, 0, 0.12)
divider(dark)  = rgba(255, 255, 255, 0.12)   ← 白線になる
```

これは `themes/index.ts` のコメントが警告していた挙動そのものだった。

> `palette.mode` を設定しない = MUI デフォルト(light)の component スタイルを維持
> 元の defaultTheme と同じ挙動になり、Stepper/Divider 等が崩れない

Experiences セクションは**モードによらず常に白背景**のため、ダークモードで Stepper の区切り線が白くなり見えなくなる。
`divider` を明示指定すれば回避できるが、`action.disabled` など mode 由来のトークンは他にもあり、潰し漏れのリスクが高い。

本来の解決策は「常に白背景 / 常にダーク背景」のセクションを**カラースキームの島**として扱うことだが、
セクション構成そのものが #79 で変わるため、その後に再検討するのが妥当と判断した。CLAUDE.md にも経緯を記載している。

## 動作確認: ベースライン比較

変更前に**ライト / ダーク両モードで 13 要素の実測値をベースラインとして採取**し、変更後に同じ計測を行って差分を検証した。

```
diffCount: 0
diffs: []
```

**26項目（13要素 × 2モード）すべて完全一致**。body / Hero / About / Experiences / Works / Header / Footer の背景色と文字色に変化なし。

回帰リスクとして特定していた箇所も確認済み。

```
stepConnectorBorderDark: rgb(189, 189, 189)   ← 白線化していない
footerDividerDark:       rgb(100, 116, 139)
```

## 確認事項

- [x] 型エラーなし (`npx tsc --noEmit`)
- [x] テスト: 13 passed (`npm test`)
- [x] Stylelint: エラーなし (`npm run lint:style`)
- [x] 表示確認: ライト / ダーク両モードでベースラインと差分 0
- [x] lint: husky の lint-staged がコミット時に確認済み
- [ ] build: CI で確認
