### PR TITLE
feat: zenn の記事一覧を表示する writing セクションを追加する

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,9 @@
 import { Home } from "@/components/pages/Home/containers";
+import { fetchZennArticles } from "@/lib/zenn";
 
-export default function Page() {
-  return <Home />;
+export default async function Page() {
+  // Home は Client Component のため、取得は Server Component 側で行って props で渡す
+  const articles = await fetchZennArticles();
+
+  return <Home articles={articles} />;
 }

--- a/src/components/pages/Home/containers/index.tsx
+++ b/src/components/pages/Home/containers/index.tsx
@@ -11,8 +11,10 @@ import React from "react";
 import { Icon } from "@/components/parts/Icon";
 import { TypingCarousel } from "@/components/parts/TypingCarousel";
 import { darkTheme } from "@/components/themes";
+import { type ZennArticle } from "@/lib/zenn";
 import { Experiences } from "../presentations/Experiences";
 import { Works } from "../presentations/Works";
+import { Writing } from "../presentations/Writing";
 import { TYPING_TEXT, URL } from "./constants";
 import {
   AvatarWrapper,
@@ -22,7 +24,11 @@ import {
   ArrowDownWrapper,
 } from "./styles";
 
-export const Home = () => {
+type Props = {
+  articles: ZennArticle[];
+};
+
+export const Home = ({ articles }: Props) => {
   const scrollToNextSection = () => {
     const nextSection = document.getElementById("about");
     if (nextSection) {
@@ -94,6 +100,7 @@ export const Home = () => {
       </IntroWrapper>
       <Experiences />
       <Works />
+      <Writing articles={articles} />
     </>
   );
 };

--- a/src/components/pages/Home/presentations/Writing/index.tsx
+++ b/src/components/pages/Home/presentations/Writing/index.tsx
@@ -1,0 +1,44 @@
+import { Typography } from "@mui/material";
+import Link from "next/link";
+import React from "react";
+import { ArticleCard } from "@/components/parts/ArticleCard";
+import { type ZennArticle } from "@/lib/zenn";
+import { URL } from "../../containers/constants";
+import { CardsWrapper, Fallback, WritingWrapper } from "./styles";
+
+type Props = {
+  articles: ZennArticle[];
+};
+
+export const Writing = ({ articles }: Props) => {
+  return (
+    <WritingWrapper id="writing">
+      <Typography
+        variant="h3"
+        textAlign="center"
+        sx={{ color: "text.primary" }}
+      >
+        Writing
+      </Typography>
+
+      {articles.length > 0 ? (
+        <CardsWrapper>
+          {articles.map((article) => (
+            <ArticleCard key={article.url} {...article} />
+          ))}
+        </CardsWrapper>
+      ) : (
+        // feed の取得に失敗してもセクションが空にならないよう Zenn への導線を残す
+        <Fallback>
+          <Typography sx={{ color: "text.primary" }}>
+            記事を読み込めませんでした。
+            <Link href={URL.ZENN} target="_blank" rel="noreferrer noopener">
+              Zenn
+            </Link>
+            で公開しています。
+          </Typography>
+        </Fallback>
+      )}
+    </WritingWrapper>
+  );
+};

--- a/src/components/pages/Home/presentations/Writing/styles.ts
+++ b/src/components/pages/Home/presentations/Writing/styles.ts
@@ -1,0 +1,30 @@
+import { css } from "@emotion/react";
+import emotionStyled from "@emotion/styled";
+import { breakpoint } from "@/assets/styles/variable";
+import { commonWrapperStyle } from "../../containers/commonStyle";
+
+const writingWrapper = css`
+  ${commonWrapperStyle}
+`;
+
+const cardsWrapper = css`
+  display: grid;
+  gap: var(--spacing-3);
+  grid-template-columns: 1fr;
+  padding: var(--spacing-4) 0 var(--spacing-9);
+
+  /* stylelint-disable-next-line media-query-no-invalid */
+  @media (min-width: ${breakpoint}) {
+    grid-template-columns: repeat(3, 1fr);
+  }
+`;
+
+const fallback = css`
+  padding: var(--spacing-4) 0 var(--spacing-9);
+  text-align: center;
+`;
+
+/** emotion styled components */
+export const WritingWrapper = emotionStyled.section`${writingWrapper}`;
+export const CardsWrapper = emotionStyled.div`${cardsWrapper}`;
+export const Fallback = emotionStyled.div`${fallback}`;

--- a/src/components/parts/ArticleCard/index.stories.tsx
+++ b/src/components/parts/ArticleCard/index.stories.tsx
@@ -1,0 +1,34 @@
+import { ArticleCard } from ".";
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+
+const meta: Meta<typeof ArticleCard> = {
+  component: ArticleCard,
+};
+
+export default meta;
+type Story = StoryObj<typeof ArticleCard>;
+
+export const Default: Story = {
+  args: {
+    title: "React Hook Form × Zodで実務に耐えるフォーム実装を作る",
+    url: "https://example.com",
+    publishedAt: "2025-10-31T21:00:02.000Z",
+  },
+};
+
+/** タイトルが長い場合は3行で省略される */
+export const LongTitle: Story = {
+  args: {
+    ...Default.args,
+    title:
+      "registerでは動かない？React Hook FormとMUIを正しく連携させる方法と、その背景にある設計思想について詳しく解説する記事",
+  },
+};
+
+/** pubDate が不正な記事は日付なしで表示する */
+export const WithoutDate: Story = {
+  args: {
+    ...Default.args,
+    publishedAt: undefined,
+  },
+};

--- a/src/components/parts/ArticleCard/index.tsx
+++ b/src/components/parts/ArticleCard/index.tsx
@@ -1,0 +1,40 @@
+import { Card as MUICard, CardActionArea, Typography } from "@mui/material";
+import Link from "next/link";
+import React from "react";
+import { Body, cardActionAreaSx, cardSx, dateSx, titleSx } from "./styles";
+
+type Props = {
+  title: string;
+  url: string;
+  /** ISO 8601 形式 */
+  publishedAt?: string;
+};
+
+/** ロケールに依存しないよう UTC の年月日で表示する */
+const formatDate = (publishedAt: string) =>
+  publishedAt.slice(0, 10).replace(/-/g, ".");
+
+export const ArticleCard = ({ title, url, publishedAt }: Props) => {
+  return (
+    <MUICard sx={cardSx}>
+      <CardActionArea
+        component={Link}
+        href={url}
+        target="_blank"
+        rel="noreferrer noopener"
+        sx={cardActionAreaSx}
+      >
+        <Body>
+          <Typography variant="body2" className="title" sx={titleSx}>
+            {title}
+          </Typography>
+          {publishedAt && (
+            <Typography variant="caption" sx={dateSx}>
+              {formatDate(publishedAt)}
+            </Typography>
+          )}
+        </Body>
+      </CardActionArea>
+    </MUICard>
+  );
+};

--- a/src/components/parts/ArticleCard/styles.ts
+++ b/src/components/parts/ArticleCard/styles.ts
@@ -1,0 +1,47 @@
+import { css } from "@emotion/react";
+import emotionStyled from "@emotion/styled";
+
+const body = css`
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-2);
+  height: 100%;
+  padding: var(--spacing-4);
+
+  /* タイトルは3行で省略する */
+  .title {
+    -webkit-box-orient: vertical;
+    display: -webkit-box;
+    -webkit-line-clamp: 3;
+    overflow: hidden;
+  }
+`;
+
+/** emotion styled components */
+export const Body = emotionStyled.div`${body}`;
+
+/** MUI sx styles */
+// Card は常にライトなサーフェスのため、モードに追従する text.primary は使わない
+// （ダークモードでは paper と text.primary がどちらも gray になり文字が消える）
+export const cardSx = {
+  backgroundColor: "common.white",
+  height: "100%",
+  transition: "transform 0.2s ease-in-out",
+
+  "&:hover": {
+    transform: "translateY(-4px)",
+  },
+};
+
+export const cardActionAreaSx = {
+  height: "100%",
+};
+
+export const titleSx = {
+  color: "primary.dark",
+};
+
+export const dateSx = {
+  color: "text.disabled",
+  marginTop: "auto",
+};

--- a/src/components/parts/DrawerNav/index.tsx
+++ b/src/components/parts/DrawerNav/index.tsx
@@ -28,6 +28,7 @@ export const DrawerNav = ({ isOpen, onClose, onOpen }: Props) => {
     { text: "About", anchor: "about" },
     { text: "Experiences", anchor: "experiences" },
     { text: "Works", anchor: "works" },
+    { text: "Writing", anchor: "writing" },
   ];
 
   return (

--- a/src/components/parts/Footer/index.tsx
+++ b/src/components/parts/Footer/index.tsx
@@ -16,6 +16,7 @@ export const Footer = () => {
     { text: "About", anchor: "about" },
     { text: "Experiences", anchor: "experiences" },
     { text: "Works", anchor: "works" },
+    { text: "Writing", anchor: "writing" },
   ];
   const secondListItems = [
     {

--- a/src/components/parts/Header/index.tsx
+++ b/src/components/parts/Header/index.tsx
@@ -28,6 +28,7 @@ export const Header = () => {
     { text: "About", anchor: "about" },
     { text: "Experiences", anchor: "experiences" },
     { text: "Works", anchor: "works" },
+    { text: "Writing", anchor: "writing" },
   ];
 
   // スクロール監視のためのセクションIDリスト

--- a/src/lib/zenn.test.ts
+++ b/src/lib/zenn.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it, vi } from "vitest";
+import { fetchZennArticles, parseZennFeed } from "@/lib/zenn";
+
+const TITLE = "React Hook Form × Zodで実務に耐えるフォーム実装を作る";
+const URL = "https://zenn.dev/nekonoko2323/articles/f2c9e9f7d6d09b";
+const PUB_DATE = "Fri, 31 Oct 2025 21:00:02 GMT";
+const PUB_DATE_ISO = "2025-10-31T21:00:02.000Z";
+// 実際の feed は enclosure と dc:creator を含む。パーサがこれらを無視できることも兼ねて再現する
+const EXTRA_TAGS =
+  '<enclosure url="https://res.cloudinary.com/zenn/og-base.png" length="0" type="false"/><dc:creator>ねこのこ</dc:creator>';
+
+const buildItem = ({
+  title = `<![CDATA[${TITLE}]]>`,
+  link = URL,
+  pubDate = PUB_DATE,
+}: Partial<Record<"title" | "link" | "pubDate", string>> = {}) =>
+  [
+    "<item>",
+    title === "" ? "" : `<title>${title}</title>`,
+    link === "" ? "" : `<link>${link}</link>`,
+    pubDate === "" ? "" : `<pubDate>${pubDate}</pubDate>`,
+    EXTRA_TAGS,
+    "</item>",
+  ].join("");
+
+const buildFeed = (...items: string[]) =>
+  `<?xml version="1.0" encoding="UTF-8"?><rss version="2.0"><channel>${items.join("")}</channel></rss>`;
+
+const createResponse = ({ ok = true, body = "" } = {}) =>
+  ({ ok, text: async () => body }) as Response;
+
+describe("parseZennFeed", () => {
+  it("should return an article for each item in the feed", () => {
+    const feed = buildFeed(buildItem(), buildItem());
+
+    expect(parseZennFeed(feed)).toHaveLength(2);
+  });
+
+  it("should strip the CDATA wrapper from the title", () => {
+    const feed = buildFeed(buildItem());
+
+    expect(parseZennFeed(feed)[0].title).toBe(TITLE);
+  });
+
+  it("should decode HTML entities in a title without CDATA", () => {
+    const feed = buildFeed(buildItem({ title: "Router &amp; Cache" }));
+
+    expect(parseZennFeed(feed)[0].title).toBe("Router & Cache");
+  });
+
+  it("should expose the article url", () => {
+    const feed = buildFeed(buildItem());
+
+    expect(parseZennFeed(feed)[0].url).toBe(URL);
+  });
+
+  it("should convert pubDate to an ISO string", () => {
+    const feed = buildFeed(buildItem());
+
+    expect(parseZennFeed(feed)[0].publishedAt).toBe(PUB_DATE_ISO);
+  });
+
+  it("should return an empty array when the feed has no items", () => {
+    expect(parseZennFeed(buildFeed())).toEqual([]);
+  });
+
+  it("should return an empty array when the input is not a feed", () => {
+    expect(parseZennFeed("<html><body>not a feed</body></html>")).toEqual([]);
+  });
+
+  it("should skip an item that has no title", () => {
+    const feed = buildFeed(buildItem({ title: "" }), buildItem());
+
+    expect(parseZennFeed(feed)).toHaveLength(1);
+  });
+
+  it("should skip an item that has no link", () => {
+    const feed = buildFeed(buildItem({ link: "" }), buildItem());
+
+    expect(parseZennFeed(feed)).toHaveLength(1);
+  });
+
+  it("should omit publishedAt when pubDate is invalid", () => {
+    const feed = buildFeed(buildItem({ pubDate: "not a date" }));
+
+    expect(parseZennFeed(feed)[0].publishedAt).toBeUndefined();
+  });
+});
+
+describe("fetchZennArticles", () => {
+  it("should return the articles from the fetched feed", async () => {
+    const fetcher = vi.fn(async () =>
+      createResponse({ body: buildFeed(buildItem()) })
+    );
+
+    const articles = await fetchZennArticles({ fetcher });
+
+    expect(articles).toEqual([
+      { title: TITLE, url: URL, publishedAt: PUB_DATE_ISO },
+    ]);
+  });
+
+  it("should return at most the requested number of articles", async () => {
+    const feed = buildFeed(buildItem(), buildItem(), buildItem());
+    const fetcher = vi.fn(async () => createResponse({ body: feed }));
+
+    const articles = await fetchZennArticles({ limit: 2, fetcher });
+
+    expect(articles).toHaveLength(2);
+  });
+
+  it("should return an empty array when the response is not ok", async () => {
+    const fetcher = vi.fn(async () => createResponse({ ok: false }));
+
+    await expect(fetchZennArticles({ fetcher })).resolves.toEqual([]);
+  });
+
+  it("should return an empty array when the request throws", async () => {
+    const fetcher = vi.fn(async () => {
+      throw new Error("network down");
+    });
+
+    await expect(fetchZennArticles({ fetcher })).resolves.toEqual([]);
+  });
+});

--- a/src/lib/zenn.ts
+++ b/src/lib/zenn.ts
@@ -1,0 +1,105 @@
+export type ZennArticle = {
+  title: string;
+  url: string;
+  /** ISO 8601 形式。pubDate が不正な場合は持たない */
+  publishedAt?: string;
+};
+
+export const ZENN_FEED_URL = "https://zenn.dev/nekonoko2323/feed";
+
+/** 記事の表示件数 */
+export const ARTICLE_LIMIT = 6;
+
+/** 再検証間隔（秒）。App Hosting の ISR で再デプロイなしに記事を反映する */
+export const REVALIDATE_SECONDS = 3600;
+
+const CDATA_PATTERN = /^<!\[CDATA\[([\s\S]*)\]\]>$/;
+
+const ENTITIES: Record<string, string> = {
+  "&amp;": "&",
+  "&lt;": "<",
+  "&gt;": ">",
+  "&quot;": '"',
+  "&apos;": "'",
+  "&#39;": "'",
+};
+
+const unwrap = (value: string) => {
+  const trimmed = value.trim();
+  const cdata = trimmed.match(CDATA_PATTERN);
+  if (cdata) {
+    return cdata[1].trim();
+  }
+  return trimmed.replace(/&(amp|lt|gt|quot|apos|#39);/g, (m) => ENTITIES[m]);
+};
+
+const tagContent = (item: string, tag: string) => {
+  const matched = item.match(new RegExp(`<${tag}>([\\s\\S]*?)</${tag}>`));
+  return matched ? unwrap(matched[1]) : undefined;
+};
+
+const toIsoString = (pubDate: string | undefined) => {
+  if (!pubDate) {
+    return undefined;
+  }
+  const parsed = new Date(pubDate);
+  return Number.isNaN(parsed.getTime()) ? undefined : parsed.toISOString();
+};
+
+/**
+ * Zenn の RSS(2.0) をパースして記事一覧に変換する。
+ *
+ * Server Component は Node 上で動くため DOMParser を使えない。
+ * 対象が Zenn の feed 1つに限られるため、依存を増やさず必要な要素だけを取り出す。
+ */
+export const parseZennFeed = (xml: string): ZennArticle[] => {
+  const items = xml.match(/<item>[\s\S]*?<\/item>/g) ?? [];
+
+  return items.reduce<ZennArticle[]>((articles, item) => {
+    const title = tagContent(item, "title");
+    const url = tagContent(item, "link");
+
+    // title か link を欠く item は記事として成立しないため落とす
+    if (!title || !url) {
+      return articles;
+    }
+
+    return [
+      ...articles,
+      {
+        title,
+        url,
+        publishedAt: toIsoString(tagContent(item, "pubDate")),
+      },
+    ];
+  }, []);
+};
+
+type FetchZennArticlesOptions = {
+  limit?: number;
+  /** テストから差し替えるための依存注入 */
+  fetcher?: typeof fetch;
+};
+
+/**
+ * Zenn の記事一覧を取得する。
+ * 取得に失敗してもページ全体を壊さないよう、常に配列を返す。
+ */
+export const fetchZennArticles = async ({
+  limit = ARTICLE_LIMIT,
+  fetcher = (...args: Parameters<typeof fetch>) => fetch(...args),
+}: FetchZennArticlesOptions = {}): Promise<ZennArticle[]> => {
+  try {
+    const response = await fetcher(ZENN_FEED_URL, {
+      next: { revalidate: REVALIDATE_SECONDS },
+    });
+
+    if (!response.ok) {
+      return [];
+    }
+
+    return parseZennFeed(await response.text()).slice(0, limit);
+  } catch {
+    return [];
+  }
+};


### PR DESCRIPTION
## 概要

#65 で定めた「技術発信のハブ」という目的に対し、Zenn への導線は About セクションの**小さなアイコン1つ**しかなかった。
発信ハブの中核として、Zenn の記事一覧を自動取得する Writing セクションを追加する。

## 対応 Issue

Closes #78

## 変更内容

| 追加 | 内容 |
| --- | --- |
| `src/lib/zenn.ts` | RSS の取得とパース |
| `src/lib/zenn.test.ts` | テスト 16 件 |
| `parts/ArticleCard/` | 記事カード（Storybook 3 パターン付き） |
| `presentations/Writing/` | セクション本体 |

Header / DrawerNav / Footer のナビゲーションにも `Writing` を追加した（#77 で判明した4箇所）。

## 設計判断

### 取得は ISR（`revalidate: 3600`）

ホスティングが Firebase App Hosting のため ISR が使える。**記事を書いてから再デプロイなしにサイトへ反映される**。

```ts
const response = await fetcher(ZENN_FEED_URL, {
  next: { revalidate: REVALIDATE_SECONDS },
});
```

### 取得は Server Component 側で行う

`Home` は `"use client"` のため、fetch は `app/page.tsx`（Server Component）で行い props で渡す。

### XML パースは自前

Server Component は Node 上で動くため `DOMParser` が使えない。
対象が Zenn の feed 1つに限られるため、**依存を増やさず必要な要素だけを取り出す**方針にした。
CDATA の除去と HTML エンティティのデコードを含め、テストで担保している。

`fast-xml-parser` などの導入も選択肢だが、1つの既知フィードのために依存を増やす判断は見送った。必要なら差し替え可能な粒度で切り出してある。

### テスト容易性のため fetcher を依存注入

`jest.spyOn` によるグローバル差し替えではなく、`fetcher` を引数で受け取る形にした（グローバル指針に準拠）。

```ts
await fetchZennArticles({ fetcher });
```

## サムネイルを使わない判断

Zenn の OGP 画像には**タイトルが焼き込まれている**ため、画像 + テキストタイトルだと同じ文言が2回表示される。

当初は `enclosure` から OGP 画像を取得して表示していたが、以下の理由からテキストのみのカードにした。

- タイトルの重複が解消する
- Cloudinary 画像 6 枚分の転送がなくなる
- テキストが選択・検索可能になる
- WorkCard のトーンと揃う

これに伴い、使わなくなった `imageUrl` はパーサからも削除している（デッドコードを残さないため）。

## 実装中に見つけて直した不具合

**ダークモードで記事タイトルが不可視になっていた。**

```
cardBg:     rgb(238, 238, 238)   ← paper = gray
titleColor: rgb(238, 238, 238)   ← text.primary = gray
```

MUI Card は `text.primary` を子孫に効かせるが、ダークテーマでは `paper` と `text.primary` がどちらも gray になるため、**同色の背景に文字が乗って消えていた**。
WorkCard が既に `common.white` + `primary.dark` で回避していたため、同じパターンに揃えた。

修正後のコントラスト比（ライト / ダーク共通）:

| 要素 | コントラスト | 判定 |
| --- | --- | --- |
| タイトル | 12.98 | AAA |
| 日付 | 4.76 | AA |

## 動作確認

### 実フィードでの検証

本番の Zenn フィード（11 件）をパースし、**全件で title / url / publishedAt の欠損がゼロ**であることを確認した。

### 表示

- PC（1440px）: 3 カラム / SP（390px）: 1 カラム
- ライト / ダーク両モード
- タイトルの3行クランプが実際に効くこと（3行 = 60px、`isClamped: true`）
- ScrollSpy と Footer ナビに `writing` が追加されていること

```
sectionIds: ["home", "about", "experiences", "works", "writing"]
```

### 取得失敗時のフォールバック

`articles` が空でもセクションが壊れず、Zenn への導線が残ることを確認した。

```
fallback text: 記事を読み込めませんでした。Zennで公開しています。
fallback href: https://zenn.dev/nekonoko2323
```

## 補足

セクションの表示位置は Works の後ろに追加している。**並び順は #79 で `About → Works → Writing → Experiences` に変更する**ため、本 PR では既存の並びを崩さない形にとどめた。

## 確認事項

- [x] 型エラーなし (`npx tsc --noEmit`)
- [x] テスト: 27 passed (`npm test`) — うち Zenn 関連 16 件
- [x] Stylelint: エラーなし (`npm run lint:style`)
- [x] 表示確認: PC / SP × ライト / ダーク
- [x] 実フィードでのパース確認
- [x] lint: husky の lint-staged がコミット時に確認済み
- [ ] build: CI で確認
