### PR TITLE
refactor: 発信導線を優先したセクション順に並び替える

### DIFF
--- a/src/components/pages/Home/containers/constants.ts
+++ b/src/components/pages/Home/containers/constants.ts
@@ -7,6 +7,32 @@ export const URL = {
   AI_RADAR: "https://ai-radar.shunniehub.com",
   AI_RADAR_REPO: "https://github.com/Shunnie816/ai-radar",
 };
+/**
+ * セクションの並び順。Header / DrawerNav / Footer / useScrollSpy が
+ * すべてここを参照するため、セクションを増減するときはここだけを編集する。
+ *
+ * 並び順は #65 の「アウトプットへの導線」を優先し、
+ * 実績（Works / Writing）を経歴（Experiences）より前に置いている。
+ */
+export const NAV_ITEMS = [
+  { text: "Home", anchor: "home" },
+  { text: "About", anchor: "about" },
+  { text: "Works", anchor: "works" },
+  { text: "Writing", anchor: "writing" },
+  { text: "Experiences", anchor: "experiences" },
+];
+
+/** Footer は先頭の Home を持たない */
+export const FOOTER_NAV_ITEMS = NAV_ITEMS.filter(
+  (item) => item.anchor !== "home"
+);
+
+/**
+ * スクロール監視の対象。
+ * useScrollSpy の useEffect 依存に渡るため、レンダーごとに生成せず定数として持つ。
+ */
+export const SECTION_IDS = NAV_ITEMS.map((item) => item.anchor);
+
 export const TYPING_TEXT = [
   "Hi, I am Nekonoko",
   "I am a Frontend Developer",

--- a/src/components/pages/Home/containers/index.tsx
+++ b/src/components/pages/Home/containers/index.tsx
@@ -98,9 +98,9 @@ export const Home = ({ articles }: Props) => {
           </Tooltip>
         </IconsWrapper>
       </IntroWrapper>
-      <Experiences />
       <Works />
       <Writing articles={articles} />
+      <Experiences />
     </>
   );
 };

--- a/src/components/parts/DrawerNav/index.tsx
+++ b/src/components/parts/DrawerNav/index.tsx
@@ -9,6 +9,7 @@ import {
 } from "@mui/material";
 import { useRouter } from "next/navigation";
 import React from "react";
+import { NAV_ITEMS } from "@/components/pages/Home/containers/constants";
 import { useThemeMode } from "@/hooks/useThemeMode";
 import { Icon } from "../Icon";
 import { ListWrapper } from "./styles";
@@ -23,13 +24,7 @@ export const DrawerNav = ({ isOpen, onClose, onOpen }: Props) => {
   const router = useRouter();
   const { mode, toggleTheme } = useThemeMode();
 
-  const listItems = [
-    { text: "Home", anchor: "home" },
-    { text: "About", anchor: "about" },
-    { text: "Experiences", anchor: "experiences" },
-    { text: "Works", anchor: "works" },
-    { text: "Writing", anchor: "writing" },
-  ];
+  const listItems = NAV_ITEMS;
 
   return (
     <SwipeableDrawer

--- a/src/components/parts/Footer/index.tsx
+++ b/src/components/parts/Footer/index.tsx
@@ -2,7 +2,10 @@ import { Divider, List, ListItemText, Typography } from "@mui/material";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import React from "react";
-import { URL } from "@/components/pages/Home/containers/constants";
+import {
+  FOOTER_NAV_ITEMS,
+  URL,
+} from "@/components/pages/Home/containers/constants";
 import { Icon } from "../Icon";
 import { Wrapper, PcWrapper, ItemWrapper, CopyRight } from "./styles";
 
@@ -12,12 +15,7 @@ export const Footer = () => {
 
   const router = useRouter();
 
-  const firstListItems = [
-    { text: "About", anchor: "about" },
-    { text: "Experiences", anchor: "experiences" },
-    { text: "Works", anchor: "works" },
-    { text: "Writing", anchor: "writing" },
-  ];
+  const firstListItems = FOOTER_NAV_ITEMS;
   const secondListItems = [
     {
       component: (

--- a/src/components/parts/Header/index.tsx
+++ b/src/components/parts/Header/index.tsx
@@ -12,6 +12,10 @@ import {
 } from "@mui/material";
 import { useRouter } from "next/navigation";
 import React, { useState } from "react";
+import {
+  NAV_ITEMS,
+  SECTION_IDS,
+} from "@/components/pages/Home/containers/constants";
 import { useScrollSpy } from "@/hooks/useScrollSpy";
 import { useThemeMode } from "@/hooks/useThemeMode";
 import { DrawerNav } from "../DrawerNav";
@@ -23,17 +27,8 @@ export const Header = () => {
   const [isOpen, setIsOpen] = useState(false);
   const { mode, toggleTheme } = useThemeMode();
 
-  const listItems = [
-    { text: "Home", anchor: "home" },
-    { text: "About", anchor: "about" },
-    { text: "Experiences", anchor: "experiences" },
-    { text: "Works", anchor: "works" },
-    { text: "Writing", anchor: "writing" },
-  ];
-
-  // スクロール監視のためのセクションIDリスト
-  const sectionIds = listItems.map((item) => item.anchor);
-  const activeSection = useScrollSpy({ sectionIds });
+  const listItems = NAV_ITEMS;
+  const activeSection = useScrollSpy({ sectionIds: SECTION_IDS });
 
   return (
     <AppBar sx={appBarSx}>

--- a/src/hooks/useScrollSpy.ts
+++ b/src/hooks/useScrollSpy.ts
@@ -6,10 +6,20 @@ interface UseScrollSpyOptions {
   rootMargin?: string;
 }
 
+/**
+ * ヘッダー直下に置く細い検出バンド（ビューポート高の 15%〜20%）。
+ *
+ * 「セクション自身の 30% が見えているか」で判定すると、背の低いセクション
+ * （Works / Writing など）が縮小されたルート内で閾値に届かず、隣のセクションが
+ * 選ばれてしまう。バンドを横切っているかどうかで判定することで、
+ * セクションの高さによらずヘッダー直下にあるセクションを正しく選べる。
+ */
+const DETECTION_BAND = "-15% 0px -80% 0px";
+
 export const useScrollSpy = ({
   sectionIds,
-  threshold = 0.3,
-  rootMargin = "-40% 0px 0px 0px",
+  threshold = 0,
+  rootMargin = DETECTION_BAND,
 }: UseScrollSpyOptions) => {
   const [activeSection, setActiveSection] = useState<string>("");
 


### PR DESCRIPTION
## 概要

#65 で定めた「技術発信のハブ」という目的に対し、アウトプットである Works / Writing が最下部にあり構成が反転していた。
発信導線を優先した並び順に変更する。

あわせて、実装中に見つけた **ScrollSpy の既存バグ**を修正した。

## 対応 Issue

Closes #79

## 変更内容

### 1. セクション順の変更（`refactor:`）

```
変更前: Hero → About → Experiences → Works → Writing
変更後: Hero → About → Works → Writing → Experiences
```

### 2. ナビゲーション定義の一本化（同コミット）

同じ配列が Header / DrawerNav / Footer の**3箇所にハードコード**されており、セクションを増減するたびに揃える必要があった（#76 / #77 で実際に漏れかけた）。

`containers/constants.ts` に集約した。

| 定数 | 用途 |
| --- | --- |
| `NAV_ITEMS` | Header / DrawerNav |
| `FOOTER_NAV_ITEMS` | Footer（先頭の Home を除く） |
| `SECTION_IDS` | `useScrollSpy` の監視対象 |

`SECTION_IDS` をモジュールレベルの定数にしたことで、**#80 から申し送りのあった参照安定性の問題も解消**した。
これまで Header で `listItems.map(...)` していたためレンダーごとに新しい配列が生まれ、`useScrollSpy` の `useEffect` が毎回再実行されて observer が作り直されていた。

### 3. ScrollSpy の修正（`fix:`）

**これは #79 の並び替え以前から存在していたバグ。**

`threshold: 0.3` は「セクション自身の 30% が縮小されたルート内に見えていること」を要求する。
Works / Writing のような**背の低いセクションは `rootMargin: -40%` のルート内で閾値に届かず**、代わりに隣の背の高いセクションが選ばれていた。

ヘッダー直下に細い検出バンド（ビューポート高の 15%〜20%）を置き、そこを横切っているかで判定する方式に変更した。セクションの高さに依存しなくなる。

## 背景色について

**変更していない。**

#77 で Skills を削除した際に About と Experiences が同色（#fff）で隣接する問題が発生していたが、**間に Works / Writing が入ることで解消した**。並び替えだけで直ったため、背景色に手を入れる必要がなかった。

変更後の並び（実測値）:

| セクション | ライト | ダーク |
| --- | --- | --- |
| Hero | `#201e43` | `#201e43` |
| About | `#ffffff` | `#ffffff` |
| Works | `#eeeeee` | `#201e43` |
| Writing | `#eeeeee` | `#201e43` |
| Experiences | `#ffffff` | `#ffffff` |
| Footer | `#201e43` | `#201e43` |

同色で隣接するのは **Works / Writing のみ**。どちらもカードグリッドのセクションで、カード自体が視覚的な区切りになること、また「アウトプット」として意味的にまとまることから、意図的に同じ帯を共有させている。

## 動作確認

### ScrollSpy（PC 1440x900）

修正の前後で同じ計測を行い、**バグが並び替え起因でないことを main 上でも確認**した。

**修正前（main / 本 PR の並び替え後、どちらも誤判定）**

| スクロール先 | main のハイライト | 並び替え後のハイライト |
| --- | --- | --- |
| about | Home ✗ | Works ✗ |
| works | Works ✓ | Writing ✗ |
| writing | Works ✗ | Writing ✓ |
| experiences | Experiences ✓ | Experiences ✓ |

**修正後**

```
allCorrect: true
home → Home / about → About / works → Works
writing → Writing / experiences → Experiences
```

### 表示

- DOM のセクション順・Header ナビ順・Footer ナビ順が一致
- PC（1440px）フルページ / SP（390px）
- ライト / ダーク両モードで背景の交互が成立
- SP で横スクロールが発生しないこと（`horizontalOverflow: false`）

## 確認事項

- [x] 型エラーなし (`npx tsc --noEmit`)
- [x] テスト: 27 passed (`npm test`)
- [x] Stylelint: エラーなし (`npm run lint:style`)
- [x] 表示確認: PC / SP × ライト / ダーク
- [x] ScrollSpy: 全5セクションで正しくハイライト
- [x] lint: husky の lint-staged がコミット時に確認済み
- [ ] build: CI で確認
