### PR TITLE
fix: セクションの余白と背景色のリズムを整える

### DIFF
--- a/src/assets/styles/colors.ts
+++ b/src/assets/styles/colors.ts
@@ -9,6 +9,12 @@
  */
 export const COLOR = {
   darkNavy: "#201e43",
+  /**
+   * ダークモードのページ背景。
+   * Hero / Footer は常に darkNavy のため、同じ色だと境界が消える。
+   * 隣り合っても切れ目が分かるよう、darkNavy をわずかに明るくしている（#97）。
+   */
+  navyTint: "#312d66",
   navy: "#134b70",
   lightNavy: "#508c9b",
   gray: "#eeeeee",

--- a/src/assets/styles/variable.ts
+++ b/src/assets/styles/variable.ts
@@ -33,7 +33,7 @@ export const variables = css`
 
   /* dark mode overrides */
   [data-color-scheme="dark"] {
-    --bg-color-default: ${COLOR.darkNavy};
+    --bg-color-default: ${COLOR.navyTint};
 
     /* --text-default はオーバーライドしない。常に darkNavy のままにする。
        ダーク背景セクション内のテキストは MUI sx で明示的に上書きする */

--- a/src/components/pages/Home/containers/commonStyle.ts
+++ b/src/components/pages/Home/containers/commonStyle.ts
@@ -1,14 +1,21 @@
 import { css } from "@emotion/react";
 import { breakpoint } from "@/assets/styles/variable";
 
-/** Home内共通のwrapper style */
+/**
+ * Home内共通のwrapper style。
+ *
+ * セクションの上下余白はここが一次情報で、各セクションでは上書きしない。
+ * 以前は下だけ 0 にして各セクションが個別に padding-bottom を足していたが、
+ * PC 幅では下の shorthand（media query 内の padding）が個別指定を打ち消してしまい、
+ * About セクションの下余白が 0 になっていた（#97）。
+ */
 export const commonWrapperStyle = css`
   display: flex;
   flex-direction: column;
-  padding: var(--spacing-14) var(--spacing-4) 0;
+  padding: var(--spacing-14) var(--spacing-4);
 
   /* stylelint-disable-next-line media-query-no-invalid */
   @media (min-width: ${breakpoint}) {
-    padding: var(--spacing-14) var(--spacing-24) 0;
+    padding: var(--spacing-14) var(--spacing-24);
   }
 `;

--- a/src/components/pages/Home/containers/index.tsx
+++ b/src/components/pages/Home/containers/index.tsx
@@ -65,27 +65,30 @@ export const Home = ({ articles }: Props) => {
         </AvatarWrapper>
       </ThemeProvider>
       <IntroWrapper id="about">
+        {/* 背景がモードで反転するセクションのため、文字色は sx で明示する（#97） */}
         <IntroDescription>
-          <Typography variant="h4">{name}</Typography>
-          <Typography variant="h6" sx={{ color: "primary.light" }}>
+          <Typography variant="h4" sx={{ color: "text.primary" }}>
+            {name}
+          </Typography>
+          <Typography variant="h6" sx={{ color: "text.secondary" }}>
             {t("role")}
           </Typography>
-          <Typography>{t("bio1")}</Typography>
-          <Typography>{t("bio2")}</Typography>
-          <Typography>{t("bio3")}</Typography>
+          <Typography sx={{ color: "text.primary" }}>{t("bio1")}</Typography>
+          <Typography sx={{ color: "text.primary" }}>{t("bio2")}</Typography>
+          <Typography sx={{ color: "text.primary" }}>{t("bio3")}</Typography>
         </IntroDescription>
         <IconsWrapper>
           <Tooltip title="GitHub">
             <IconButton>
               <Link href={URL.GITHUB} target="_blank" rel="noreferrer noopener">
-                <Icon icon="gitHub" color="primary" />
+                <Icon icon="gitHub" sx={{ color: "text.primary" }} />
               </Link>
             </IconButton>
           </Tooltip>
           <Tooltip title="Zenn">
             <IconButton>
               <Link href={URL.ZENN} target="_blank" rel="noreferrer noopener">
-                <Icon icon="zenn" color="primary" />
+                <Icon icon="zenn" sx={{ color: "text.primary" }} />
               </Link>
             </IconButton>
           </Tooltip>

--- a/src/components/pages/Home/containers/styles.ts
+++ b/src/components/pages/Home/containers/styles.ts
@@ -48,7 +48,9 @@ const arrowDownWrapper = css`
 
 const introWrapper = css`
   ${commonWrapperStyle}
-  background-color: var(--bg-color-light);
+
+  /* セクションの背景は Hero(dark) から交互に切り替える（#97） */
+  background-color: var(--bg-color-default);
 `;
 
 const introDescription = css`

--- a/src/components/pages/Home/containers/styles.ts
+++ b/src/components/pages/Home/containers/styles.ts
@@ -49,9 +49,6 @@ const arrowDownWrapper = css`
 const introWrapper = css`
   ${commonWrapperStyle}
   background-color: var(--bg-color-light);
-
-  /* SkillLevel が担っていた下部の余白を wrapper 側で持つ */
-  padding-bottom: var(--spacing-14);
 `;
 
 const introDescription = css`

--- a/src/components/pages/Home/presentations/Experiences/styles.ts
+++ b/src/components/pages/Home/presentations/Experiences/styles.ts
@@ -1,17 +1,10 @@
 import { css } from "@emotion/react";
 import emotionStyled from "@emotion/styled";
-import { breakpoint } from "@/assets/styles/variable";
 import { commonWrapperStyle } from "../../containers/commonStyle";
 
 const experienceWrapper = css`
   ${commonWrapperStyle}
   background-color: var(--bg-color-light);
-  padding-bottom: var(--spacing-9);
-
-  /* stylelint-disable-next-line media-query-no-invalid */
-  @media (min-width: ${breakpoint}) {
-    padding-bottom: var(--spacing-9);
-  }
 `;
 
 /** emotion styled components */

--- a/src/components/pages/Home/presentations/Works/index.tsx
+++ b/src/components/pages/Home/presentations/Works/index.tsx
@@ -10,11 +10,8 @@ export const Works = () => {
 
   return (
     <WorksWrapper id="works">
-      <Typography
-        variant="h3"
-        textAlign="center"
-        sx={{ color: "text.primary" }}
-      >
+      {/* 常に白背景のため、Experiences と同じく body の文字色を継承する（#97） */}
+      <Typography variant="h3" textAlign="center">
         My Works
       </Typography>
       <CardsWrapper>

--- a/src/components/pages/Home/presentations/Works/styles.ts
+++ b/src/components/pages/Home/presentations/Works/styles.ts
@@ -5,6 +5,7 @@ import { commonWrapperStyle } from "../../containers/commonStyle";
 
 const worksWrapper = css`
   ${commonWrapperStyle}
+  background-color: var(--bg-color-light);
 `;
 
 const cardsWrapper = css`

--- a/src/components/pages/Home/presentations/Works/styles.ts
+++ b/src/components/pages/Home/presentations/Works/styles.ts
@@ -11,7 +11,9 @@ const cardsWrapper = css`
   display: flex;
   flex-direction: column;
   gap: var(--spacing-3);
-  padding: var(--spacing-4) 0 var(--spacing-9);
+
+  /* 下の余白はセクションの wrapper が持つ */
+  padding-top: var(--spacing-4);
 
   /* stylelint-disable-next-line media-query-no-invalid */
   @media (min-width: ${breakpoint}) {

--- a/src/components/pages/Home/presentations/Writing/styles.ts
+++ b/src/components/pages/Home/presentations/Writing/styles.ts
@@ -5,6 +5,7 @@ import { commonWrapperStyle } from "../../containers/commonStyle";
 
 const writingWrapper = css`
   ${commonWrapperStyle}
+  background-color: var(--bg-color-default);
 `;
 
 const cardsWrapper = css`

--- a/src/components/pages/Home/presentations/Writing/styles.ts
+++ b/src/components/pages/Home/presentations/Writing/styles.ts
@@ -11,7 +11,9 @@ const cardsWrapper = css`
   display: grid;
   gap: var(--spacing-3);
   grid-template-columns: 1fr;
-  padding: var(--spacing-4) 0 var(--spacing-9);
+
+  /* 下の余白はセクションの wrapper が持つ */
+  padding-top: var(--spacing-4);
 
   /* stylelint-disable-next-line media-query-no-invalid */
   @media (min-width: ${breakpoint}) {
@@ -20,7 +22,7 @@ const cardsWrapper = css`
 `;
 
 const fallback = css`
-  padding: var(--spacing-4) 0 var(--spacing-9);
+  padding-top: var(--spacing-4);
   text-align: center;
 `;
 


### PR DESCRIPTION
## 概要

セクションの上下余白を揃え、Hero から Footer まで背景色が交互になるようにしました。
Issue で挙がっていた「Writing をフッターの上に移す」案ではなく、**並び順は #88 の意図どおり維持して背景色だけ入れ替える案A**を採用しています。

## 対応 Issue

Closes #97

## 変更内容

### 余白

`commonWrapperStyle` が `padding: 56px 16px 0`（下だけ 0）で、各セクションが個別に `padding-bottom` を足す作りになっていました。
このため **PC 幅では media query 内の `padding` shorthand が個別指定を打ち消し、About セクションの下余白が 0px** になっていました（SP 幅では 56px で効いていたため、PC で見たときだけ「下が狭い」状態）。

上下の余白を `commonWrapperStyle` の一次情報にして、各セクションからは上書きを外しました。

| セクション | 修正前（PC） | 修正後 |
| --- | --- | --- |
| About | 上56 / **下0** | 56 / 56 |
| My Works・Writing | 上56 / 下36（カード側） | 56 / 56 |
| Experiences | 上56 / 下36 | 56 / 56 |

### 背景色

```
Hero(dark) → About(default) → Works(light) → Writing(default) → Experiences(light) → Footer(dark)
```

About と My Works の背景を入れ替えて交互にしました。ナビの並び・アンカー id には影響しません。

あわせて、案A を入れる過程で必要になった対応が2件あります。

**1. ダークモードのページ背景に `COLOR.navyTint`（#312d66）を追加**

`--bg-color-default` はダークモードで darkNavy、つまり Hero / Footer と同じ色でした。
そのままだと「Works/Writing が同色」という問題が「Hero/About が同色」に移動するだけだったため、
ページ背景専用に darkNavy をわずかに明るくした色を足しています。

**2. 文字色をモードに追従させた**

「ダーク背景になるセクションだけ `sx` で文字色を明示する」という既存の作りのため、背景を入れ替えると文字が消えます。

- 背景がモードで反転するようになった About … `text.primary` / `text.secondary` を明示
- 常に白背景になった My Works の見出し … Experiences と同じく body の文字色を継承

## 確認事項

- [x] 型エラーなし (`npx tsc --noEmit`)
- [x] lint: husky の lint-staged がコミット時に確認済み
- [x] テスト: `npm test` 33件 通過
- [ ] build: CI で確認

## 動作確認

ライト / ダーク × PC(1280) / SP(390) の4通りをブラウザの実測値で確認しました。

- 隣接セクションの同色: **0箇所**（4通りすべて）
- 上下余白: 全セクション 56px / 56px
- 横スクロール: なし
- 文字コントラスト: すべて 4.1:1 以上（About の役割の行のみダークモードで 3.28:1。h6 サイズのため許容と判断）

## レビュー時に見てほしい点

- 追加した `COLOR.navyTint`（#312d66）の色味
- My Works が白背景になったことで **WorkCard が白地に白**になります。カードヘッダーの色帯と elevation の影で輪郭は出ていますが、#98（カードの大きさを揃える）で一緒に見直すのが自然だと考えています

🤖 Generated with [Claude Code](https://claude.com/claude-code)
