### PR TITLE
fix: 経歴セクションの読みやすさと数字の位置を直す

### DIFF
--- a/src/components/parts/ExperienceStep/index.tsx
+++ b/src/components/parts/ExperienceStep/index.tsx
@@ -8,7 +8,7 @@ import {
 } from "@mui/material";
 import { useTranslations } from "next-intl";
 import React from "react";
-import { ProjectWrapper, TitleWrapper } from "./styles";
+import { ProjectWrapper, TitleWrapper, stepLabelSx } from "./styles";
 
 export type ExperienceStepProps = {
   title: string;
@@ -30,7 +30,7 @@ export const ExperienceStep = ({
 
   return (
     <Step expanded {...stepProps}>
-      <StepLabel>
+      <StepLabel sx={stepLabelSx}>
         <TitleWrapper>
           <Typography variant="h6" sx={{ color: "primary.light" }}>
             {title}

--- a/src/components/parts/ExperienceStep/index.tsx
+++ b/src/components/parts/ExperienceStep/index.tsx
@@ -1,4 +1,5 @@
 import {
+  Chip,
   Step,
   StepContent,
   StepLabel,
@@ -41,23 +42,37 @@ export const ExperienceStep = ({
       </StepLabel>
       <StepContent>
         <ProjectWrapper>
-          <Typography variant="body2">{description}</Typography>
+          {/* 1行の概要が最も小さい文字だったため、箇条書きより大きくして拾い読みできるようにする（#100） */}
+          <Typography variant="body1">{description}</Typography>
           <div className="details">
             <div>
-              <Typography sx={{ fontWeight: "bold", color: "primary.main" }}>
+              <Typography
+                variant="body2"
+                sx={{ fontWeight: "bold", color: "primary.main" }}
+              >
                 {t("skillSets")}
               </Typography>
-              {skillSets.map((skill) => (
-                <Typography key={skill}>- {skill}</Typography>
-              ))}
+              {/* My Works のカードと同じ Chip 表現に揃える（#100） */}
+              <div className="skills">
+                {skillSets.map((skill) => (
+                  <Chip key={skill} label={skill} color="primary" />
+                ))}
+              </div>
             </div>
             <div>
-              <Typography sx={{ fontWeight: "bold", color: "primary.main" }}>
+              <Typography
+                variant="body2"
+                sx={{ fontWeight: "bold", color: "primary.main" }}
+              >
                 {t("responsibilities")}
               </Typography>
-              {responsibilities.map((resp) => (
-                <Typography key={resp}>- {resp}</Typography>
-              ))}
+              <div className="responsibilities">
+                {responsibilities.map((resp) => (
+                  <Typography key={resp} variant="body2">
+                    - {resp}
+                  </Typography>
+                ))}
+              </div>
             </div>
           </div>
         </ProjectWrapper>

--- a/src/components/parts/ExperienceStep/styles.ts
+++ b/src/components/parts/ExperienceStep/styles.ts
@@ -9,8 +9,24 @@ const projectWrapper = css`
   .details {
     display: flex;
     flex-direction: column;
+    gap: var(--spacing-3);
+    margin-top: var(--spacing-3);
+  }
+
+  .skills {
+    display: flex;
+    flex-wrap: wrap;
     gap: var(--spacing-2);
     margin-top: var(--spacing-2);
+  }
+
+  .responsibilities {
+    margin-top: var(--spacing-2);
+
+    /* 箇条書きが詰まって読みにくいため、Typography の line-height を上書きして行間を広げる（#100） */
+    p {
+      line-height: 1.9;
+    }
   }
 
   /* stylelint-disable-next-line media-query-no-invalid */

--- a/src/components/parts/ExperienceStep/styles.ts
+++ b/src/components/parts/ExperienceStep/styles.ts
@@ -46,3 +46,18 @@ const titleWrapper = css`
 
 export const ProjectWrapper = emotionStyled.div`${projectWrapper}`;
 export const TitleWrapper = emotionStyled.div`${titleWrapper}`;
+
+/** MUI sx styles */
+/**
+ * StepLabel の中身が「タイトル + 期間」の2行のため、
+ * 既定の align-items: center では数字がラベル全体の中央 = タイトルより下に来る。
+ * 上寄せにしたうえで、24px の数字の中心がタイトル1行目（line-height 32px）の中心に
+ * 合うよう 4px だけ下げる（#99）。
+ */
+export const stepLabelSx = {
+  alignItems: "flex-start",
+
+  "& .MuiStepLabel-iconContainer": {
+    pt: 0.5,
+  },
+};


### PR DESCRIPTION
## 概要

Experiences セクションの読みやすさと、Stepper の数字の位置ズレをまとめて直しました。

どちらも `ExperienceStep` の同じ箇所を触るため、**1ブランチ・2コミットで1つの PR** にしています。
分けたほうがよければ言ってください。

## 対応 Issue

Closes #100
Closes #99

## 変更内容

### 1. 経歴の情報の強弱をつけて読みやすくする（#100）

1行の概要が箇条書きより小さい文字（body2 = 0.875rem < 箇条書き 1rem）で、拾い読みができない状態でした。大小関係を逆にして概要を目立たせています。

| 要素 | 変更前 | 変更後 |
| --- | --- | --- |
| 概要 | body2 (0.875rem) | **body1 (1rem)** |
| 使用技術 / 担当業務 の見出し | body1 (1rem) | body2 (0.875rem) |
| 担当業務の箇条書き | body1 (1rem) / 行間 1.5 | body2 (0.875rem) / **行間 1.9** |
| 使用技術 | `- TypeScript` の箇条書き | **Chip**（My Works と同じ見せ方） |

使用技術が Chip になったことで、1プロジェクトあたり最大5行あった箇条書きが1〜2行に減っています。

### 2. 数字と見出しの高さを揃える（#99）

`StepLabel` の中身が「タイトル + 期間」の2行構成のため、MUI 既定の `align-items: center` では数字がラベル全体の中央に来ていました。実測で**タイトル1行目の中心より 10px 下**にずれていました。

数字を上寄せにしたうえで、24px の数字の中心がタイトル1行目（line-height 32px）の中心に重なるよう 4px だけ下げています。

## 確認事項

- [x] 型エラーなし (`npx tsc --noEmit`)
- [x] lint: husky の lint-staged がコミット時に確認済み
- [x] テスト: `npm test` 33件 通過
- [ ] build: CI で確認

## 動作確認

日本語 / 英語 × PC(1280) / SP(390) で、数字とタイトル1行目の中心のズレを実測しました。

| | 修正前 | 修正後 |
| --- | --- | --- |
| 全ステップ | 10px 下にズレ | **0.00px** |

タイトルが2行に折り返すケース（日本語 SP の1件目、英語 SP の3・4件目）でも 0.00px で、
折り返しても1行目に揃うようになっています。横スクロールが出ないことも確認済みです。

## レビュー時に見てほしい点

- **担当業務の箇条書きを 1rem → 0.875rem に下げている点。**「細かい文字の箇条書きが多い」という指摘に対して文字を小さくするのは一見逆ですが、概要を拾い読みできるようにするための強弱づけとして下げています。読みにくければ 1rem に戻して、概要側を上げる方向に変えられます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
