### PR TITLE
fix: 白背景でカードの輪郭が出るようにする

### DIFF
--- a/src/components/parts/ArticleCard/styles.ts
+++ b/src/components/parts/ArticleCard/styles.ts
@@ -25,6 +25,9 @@ export const Body = emotionStyled.div`${body}`;
 // （ダークモードでは paper と text.primary がどちらも gray になり文字が消える）
 export const cardSx = {
   backgroundColor: "common.white",
+  // WorkCard と縁の見え方を揃える（#98）
+  border: "1px solid",
+  borderColor: "divider",
   height: "100%",
   transition: "transform 0.2s ease-in-out",
 

--- a/src/components/parts/WorkCard/styles.ts
+++ b/src/components/parts/WorkCard/styles.ts
@@ -20,8 +20,12 @@ export const LinkContainer = emotionStyled.div`${linkContainer}`;
 export const LinksWrapper = emotionStyled.div`${linksWrapper}`;
 
 /** MUI sx styles */
+// My Works は白背景のセクションのため、影だけではカードの輪郭が出ない。
+// 枠線で縁を立てる（#98）
 export const cardSx = {
   backgroundColor: "common.white",
+  border: "1px solid",
+  borderColor: "divider",
 };
 
 export const cardHeaderSx = {

--- a/src/components/themes/index.ts
+++ b/src/components/themes/index.ts
@@ -30,7 +30,9 @@ export const darkTheme = createTheme({
     },
     secondary: {
       main: COLOR_PALETTE.gray,
-      light: COLOR_PALETTE.lightGray,
+      // 唯一の利用先が WorkCard のヘッダー帯で、カードは常に白いサーフェス。
+      // lightGray だと白地に埋もれるため、lightTheme と同じ lightBlue に揃える（#98）
+      light: COLOR_PALETTE.lightBlue,
       dark: COLOR_PALETTE.mediumGray,
     },
     text: {


### PR DESCRIPTION
## 概要

#97 で My Works が白背景になった結果、白いカードが背景と同化して輪郭が影だけになっていた問題を直します。

Issue のコメントを受けて、**スコープを「カードの大きさを揃える」から「白背景でカードがぼやける問題を直す」に差し替え**ました。
当初挙げていたレイアウト統一（flex → grid）とカード高さ揃えは、カードの大きさは現状問題なしとのことで**対応不要**として落としています。

## 対応 Issue

Closes #98

## 原因

### 1. カードに輪郭がない

| | 色 |
| --- | --- |
| My Works セクション背景 | `#ffffff` |
| カード地色（`common.white`） | `#ffffff` |

コントラスト比 **1.00**。枠線が無く、elevation-1 の影だけが頼りでした。

### 2. ヘッダー帯がモードに追従してしまう

ヘッダー帯が参照している `secondary.light` の値がテーマごとに違いました。

| モード | `secondary.light` | 白いカード上での見え方 |
| --- | --- | --- |
| ライト | lightBlue `#eef7ff` | 薄いが見える |
| ダーク | lightGray `#fafafa` | ほぼ消える |

カードは常に白いサーフェスなので、ここがモード追従なのは `ArticleCard` に既に書かれている注意（「Card は常にライトなサーフェスのため、モードに追従する text.primary は使わない」）と同じ性質のズレです。

## 変更内容

- カードに `1px solid divider` の枠線を足す
  - **WorkCard / ArticleCard の両方**に入れて、2つのセクションでカードの縁の見え方を揃える
  - `divider` は lightTheme / darkTheme のどちらも `rgba(0,0,0,0.12)`（darkTheme は `palette.mode` を設定していないため）なので、両モードで同じ色になる
- `darkTheme` の `secondary.light` を lightGray → lightBlue に変える
  - `secondary.light` の利用先はリポジトリ内で WorkCard のヘッダー帯のみであることを確認済み

## 確認事項

- [x] 型エラーなし (`npx tsc --noEmit`)
- [x] lint: husky の lint-staged がコミット時に確認済み
- [x] テスト: `npm test` 33件 通過
- [ ] build: CI で確認

## 動作確認

ライト / ダーク × PC(1280) / SP(390) で確認しました。

- ヘッダー帯: 両モードとも lightBlue `#eef7ff` に統一
- 枠線: 両カード・両モードとも `1px solid rgba(0,0,0,0.12)`
- SP でカード幅が WorkCard / ArticleCard ともに 343px で一致、横スクロールなし

カードは常に白いサーフェスなので、**ライトとダークでカードの見た目が同一**になります（意図どおり）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
