### PR TITLE
docs: README を刷新してライセンス情報を整備する

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024-2026 Nekonoko
+Copyright (c) 2026 Shunnie816
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024-2026 Nekonoko
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.en.md
+++ b/README.en.md
@@ -1,0 +1,87 @@
+# Portfolio Website
+
+[日本語](./README.md) | English
+
+The portfolio website of Nekonoko, a frontend engineer.
+It brings together my work history, personal projects, and technical writing.
+
+🔗 **https://shunniehub.com**
+
+## Features
+
+- **Japanese / English switching** — each language is served under `/ja` and `/en`, while `/` redirects based on the browser's language settings
+- **Light / dark theme** — switchable from the header, and the choice is remembered on the next visit
+- **Auto-updating article list** — the latest posts are fetched from the Zenn RSS feed
+- **Container / Presentation pattern** — logic and presentation are separated, and each UI component can be reviewed in isolation with Storybook
+
+## Tech Stack
+
+| Category | Technology |
+| --- | --- |
+| Framework | Next.js 16 (App Router) |
+| Language | TypeScript 5 / React 19 |
+| UI | MUI (Material UI) v7 |
+| Styling | Emotion (styled) + CSS custom properties |
+| Internationalization | next-intl |
+| Component development | Storybook 10 (Vite based) |
+| Testing | Vitest + React Testing Library |
+| Lint / Format | ESLint 9 (Flat Config) / Prettier / Stylelint |
+| Hosting | Firebase App Hosting (SSR / ISR) |
+
+## Getting Started
+
+Requirements: **Node.js 22**
+
+```bash
+npm ci
+npm run dev
+```
+
+The site runs at http://localhost:3000.
+
+## Scripts
+
+```bash
+npm run dev             # Start the dev server (localhost:3000)
+npm run build           # Production build
+npm run start           # Start the production server
+npm run lint            # Run ESLint
+npm run lint:style      # Run Stylelint
+npm run lint:style:fix  # Fix Stylelint issues
+npm run storybook       # Start Storybook (localhost:6006)
+npm run build-storybook # Build Storybook
+npm test                # Run Vitest once and exit
+npm run test:watch      # Run Vitest in watch mode
+```
+
+## Project Structure
+
+```
+messages/                  # Translation resources (en.json / ja.json)
+src/
+├── app/[locale]/          # Per-language routes (/en, /ja)
+├── assets/styles/         # Global styles and design tokens
+├── components/
+│   ├── pages/             # Page-level components
+│   │   └── Home/
+│   │       ├── containers/    # Logic layer
+│   │       └── presentations/ # Presentation layer
+│   ├── parts/             # Shared UI components
+│   └── themes/            # MUI theme configuration
+├── contexts/              # React Context
+├── hooks/                 # Custom hooks
+├── i18n/                  # next-intl configuration
+├── lib/                   # External data fetching (Zenn RSS, etc.)
+└── proxy.ts               # Language detection and redirects
+```
+
+## Deployment
+
+The site is hosted on Firebase App Hosting and deploys automatically when changes are merged into `main`.
+
+## License
+
+**The source code is released under the [MIT License](./LICENSE)** — feel free to read and reuse it.
+
+However, **the content (profile, work history, text, and images) is not covered by that license** and all rights are reserved.
+Please use this repository as a reference for its implementation.

--- a/README.md
+++ b/README.md
@@ -1,32 +1,87 @@
-# Portfolio Website
+# ポートフォリオサイト
 
-Welcome to my portfolio website! This site showcases my skills, projects, and experience as a frontend developer.
+日本語 | [English](./README.en.md)
 
-## Overview
+フロントエンドエンジニア「ねこのこ」のポートフォリオサイトです。
+経歴・個人開発・技術記事をまとめて公開しています。
 
-This portfolio site is designed to highlight my work and expertise in frontend development. It features:
+🔗 **https://shunniehub.com**
 
-- Professional Experience: Details of my work history and roles in various projects.
-- Skills: An overview of my technical skills, including frontend technologies, tools, and frameworks.
-- Projects: A collection of personal and professional projects that demonstrate my abilities and interests.
+## 特徴
 
-## Technology Stack
+- **日本語 / 英語の切り替え** — `/ja` `/en` で各言語のページを提供し、`/` はブラウザの言語設定を見て振り分けます
+- **ライト / ダークテーマ** — ヘッダーから切り替えでき、選択は次回以降も保持されます
+- **記事一覧の自動更新** — Zenn の RSS から最新の投稿を取得して表示します
+- **Container / Presentation パターン** — ロジックと表示を分離し、UI は Storybook で個別に確認できます
 
-The site is built using the following technologies:
+## 技術スタック
 
-- TypeScript: For type safety and improved developer experience.
-- React: To build reusable UI components and manage state.
-- Next.js: For server-side rendering, static site generation, and optimized performance.
-- MUI: For a modern and consistent UI design system.
-- Sass: For advanced styling capabilities and maintainable CSS.
-- Storybook: For developing and testing UI components in isolation.
-- Firebase: For hosting the site.
+| 分類 | 使用技術 |
+| --- | --- |
+| フレームワーク | Next.js 16（App Router） |
+| 言語 | TypeScript 5 / React 19 |
+| UI | MUI (Material UI) v7 |
+| スタイリング | Emotion（styled）+ CSS カスタムプロパティ |
+| 多言語化 | next-intl |
+| コンポーネント開発 | Storybook 10（Vite ベース） |
+| テスト | Vitest + React Testing Library |
+| Lint / Format | ESLint 9（Flat Config）/ Prettier / Stylelint |
+| ホスティング | Firebase App Hosting（SSR / ISR 対応） |
 
-## Deployment
+## セットアップ
 
-The site is deployed on Firebase Hosting. The deployment is automatically triggered on code merges to the main branch.
+必要環境: **Node.js 22**
 
-## Future Improvements
+```bash
+npm ci
+npm run dev
+```
 
-- Implement additional features such as animations and theme switching.
-- Enhance design elements and add more interactive components.
+http://localhost:3000 で起動します。
+
+## スクリプト
+
+```bash
+npm run dev             # 開発サーバー起動 (localhost:3000)
+npm run build           # プロダクションビルド
+npm run start           # プロダクションサーバー起動
+npm run lint            # ESLint 実行
+npm run lint:style      # Stylelint 実行
+npm run lint:style:fix  # Stylelint 自動修正
+npm run storybook       # Storybook 起動 (localhost:6006)
+npm run build-storybook # Storybook ビルド
+npm test                # Vitest 実行（1回だけ実行して終了）
+npm run test:watch      # Vitest ウォッチモード
+```
+
+## ディレクトリ構成
+
+```
+messages/                  # 翻訳リソース（en.json / ja.json）
+src/
+├── app/[locale]/          # 言語ごとのルート（/en, /ja）
+├── assets/styles/         # グローバルスタイル・デザイントークン
+├── components/
+│   ├── pages/             # ページ単位のコンポーネント
+│   │   └── Home/
+│   │       ├── containers/    # ロジック層
+│   │       └── presentations/ # 表示層
+│   ├── parts/             # 共通 UI コンポーネント
+│   └── themes/            # MUI テーマ設定
+├── contexts/              # React Context
+├── hooks/                 # カスタムフック
+├── i18n/                  # next-intl の設定
+├── lib/                   # 外部データ取得（Zenn RSS など）
+└── proxy.ts               # 言語判定とリダイレクト
+```
+
+## デプロイ
+
+Firebase App Hosting でホストしています。`main` へのマージをトリガーに自動デプロイされます。
+
+## ライセンス
+
+**ソースコードは [MIT License](./LICENSE)** です。自由に参照・再利用いただけます。
+
+ただし、**掲載内容（プロフィール・経歴・文章・画像）はライセンスの対象外**で、著作権はすべて留保します。
+サイトの実装を参考にする目的でご利用ください。

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "portfolio-site",
   "version": "0.1.0",
   "private": true,
+  "license": "MIT",
   "scripts": {
     "dev": "next dev",
     "build": "next build",

--- a/src/components/parts/Footer/index.tsx
+++ b/src/components/parts/Footer/index.tsx
@@ -87,7 +87,7 @@ export const Footer = () => {
 
       <CopyRight>
         <Typography variant="caption" sx={{ color: "text.disabled" }}>
-          © {currentYear} Nekonoko. All rights are reserved.
+          © {currentYear} Nekonoko. All rights reserved.
         </Typography>
       </CopyRight>
     </Wrapper>


### PR DESCRIPTION
## 概要

README の刷新とライセンス情報の整備を行いました。
**#95 の「README にライセンスを明記する」が #103 の README 全面刷新と同じファイルを触る**ため、1つの PR にまとめています。

## 対応 Issue

Closes #103
Closes #95

## 変更内容

### ライセンス情報の整備（#95）

方針は Issue で確定した「**コードは MIT、掲載内容（文章・画像・プロフィール）は対象外**」に従っています。

- `LICENSE`（MIT）を追加。著作権表記は `2024-2026 Nekonoko`（最初のコミットが 2024 年）
- `package.json` に `"license": "MIT"` を追加
- フッターの `All rights are reserved.` → `All rights reserved.`（慣用表現に合わせる）

**掲載内容が対象外である旨は LICENSE 本文には書かず、README に記載しました。**
MIT の本文に段落を足すと GitHub のライセンス判定が `Other` に落ちる可能性があるためです。

### README の刷新（#103）

実態との乖離を解消しました。

| 項目 | 修正前 | 修正後 |
| --- | --- | --- |
| Sass | 技術スタックに記載 | 削除（#80 で撤去済み。Emotion に一本化） |
| ホスティング | Firebase Hosting | Firebase App Hosting（SSR / ISR 対応） |
| 多言語化 / Vitest / Storybook | 記載なし | 追記 |
| バージョン | 記載なし | Next.js 16 / React 19 / MUI v7 などを明記 |
| セットアップ手順 | 記載なし | Node.js 22 / `npm ci` / `npm run dev` |
| スクリプト一覧 | 記載なし | 追記 |
| ディレクトリ構成 | 記載なし | 追記 |
| サイト URL | 記載なし | https://shunniehub.com |
| 「Future Improvements」 | テーマ切り替えが未実装扱い | 削除（#80 で実装済み） |

言語の切り替えは、`README.md`（日本語・メイン）と `README.en.md`（英語）を用意し、
冒頭に `日本語 | English` のリンクを置いて相互に行き来できるようにしています。

## 確認事項

- [x] 型エラーなし (`npx tsc --noEmit`)
- [x] lint: husky の lint-staged がコミット時に確認済み
- [x] テスト: `npm test` 33件 通過
- [ ] build: CI で確認

## レビュー時に見てほしい点

- **LICENSE の著作権者名を `Nekonoko` にしています。** GitHub アカウント名（Shunnie816）や本名にしたい場合は差し替えてください
- **年の表記を `2024-2026` にしています。** 最初のコミットが 2024 年のためですが、単年表記に変えても構いません
- README の「特徴」に挙げた4点（言語切り替え / テーマ / Zenn RSS / Container-Presentation）が、
  訴求したいポイントとして妥当かどうか

🤖 Generated with [Claude Code](https://claude.com/claude-code)
